### PR TITLE
Make splat scene downloads abort-able

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,7 @@ To run the built-in viewer:
 const viewer = new GaussianSplats3D.Viewer({
     'cameraUp': [0, -1, -0.6],
     'initialCameraPosition': [-1, -4, 6],
-    'initialCameraLookAt': [0, 4, 0],
-    'halfPrecisionCovariancesOnGPU': true,
+    'initialCameraLookAt': [0, 4, 0]
 });
 viewer.loadFile('<path to .ply, .ksplat, or .splat file>', {
     'splatAlphaRemovalThreshold': 5,
@@ -233,7 +232,8 @@ const viewer = new GaussianSplats3D.Viewer({
     'camera': camera,
     'useBuiltInControls': false,
     'ignoreDevicePixelRatio': false,
-    'gpuAcceleratedSort': true
+    'gpuAcceleratedSort': true,
+    'halfPrecisionCovariancesOnGPU': true,
 });
 viewer.loadFile('<path to .ply, .ksplat, or .splat file>')
 .then(() => {
@@ -257,7 +257,7 @@ Advanced `Viewer` parameters
 | `renderer` | Pass an instance of a Three.js `Renderer` to the viewer, otherwise it will create its own. Defaults to `undefined`.
 | `camera` | Pass an instance of a Three.js `Camera` to the viewer, otherwise it will create its own. Defaults to `undefined`.
 | `ignoreDevicePixelRatio` | Tells the viewer to pretend the device pixel ratio is 1, which can boost performance on devices where it is larger, at a small cost to visual quality. Defaults to `false`.
-| `gpuAcceleratedSort` | Tells the viewer to use a partially GPU-accelerated approach to sorting splats. Currently this means pre-computation of splat distances from the camera is performed on the GPU. Defaults to `true`.
+| `gpuAcceleratedSort` | Tells the viewer to use a partially GPU-accelerated approach to sorting splats. Currently this means pre-computation of splat distances from the camera is performed on the GPU. Defaults to `false` on mobile devices, `true` otherwise.
 | `halfPrecisionCovariancesOnGPU` | Tells the viewer to use 16-bit floating point values when storing splat covariance data in textures, instead of 32-bit. Defaults to `true`.
 <br>
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -509,7 +509,7 @@
       document.body.style.backgroundColor = "#000000";
       history.pushState("ViewSplat", null);
       const viewer = new GaussianSplats3D.Viewer(viewerOptions);
-      viewer.loadSplatBuffersIntoMesh([splatBuffer], [splatBufferOptions])
+      viewer.addSplatBuffers([splatBuffer], [splatBufferOptions])
       .then(() => {
           viewer.start();
       });

--- a/demo/test.html
+++ b/demo/test.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="x-ua-compatible" content="ie=edge">
+  <title>3D Gaussian Splat Demo - Garden</title>
+  <script type="text/javascript" src="js/util.js"></script>
+  <script type="importmap">
+    {
+        "imports": {
+            "three": "./lib/three.module.js",
+            "gaussian-splats-3d": "./lib/gaussian-splats-3d.module.js"
+        }
+    }
+  </script>
+  <style>
+
+    body {
+      background-color: #000000;
+      height: 100vh;
+      margin: 0px;
+    }
+
+  </style>
+
+</head>
+
+<body>
+  <script type="module">
+    import * as GaussianSplats3D from 'gaussian-splats-3d';
+    import * as THREE from 'three';
+    const viewer = new GaussianSplats3D.Viewer({
+      'cameraUp': [0, -1, -0.54],
+      'initialCameraPosition': [-3.15634, -0.16946, -0.51552],
+      'initialCameraLookAt': [1.52976, 2.27776, 1.65898],
+      'halfPrecisionCovariancesOnGPU': true
+    });
+    const abortablePromise = viewer.loadFiles([{
+          'path': 'assets/data/garden/garden_high.ksplat',
+          'splatAlphaRemovalThreshold': 20,
+        },
+        {
+          'path': 'assets/data/bonsai/bonsai_trimmed.ksplat',
+          'rotation': [-0.14724434, -0.0761755, 0.1410657, 0.976020],
+          'scale': [1.5, 1.5, 1.5],
+          'position': [-3, -2, -3.2],
+          'splatAlphaRemovalThreshold': 20,
+        }]);
+    abortablePromise.then(() => {
+        console.log("Done");
+    })
+    .catch((error) => {
+        console.log(error)
+    });
+
+    window.setTimeout(() => {
+        abortablePromise.abort();
+    }, 2000);
+  </script>
+</body>
+
+</html>

--- a/demo/test.html
+++ b/demo/test.html
@@ -47,8 +47,9 @@
           'scale': [1.5, 1.5, 1.5],
           'position': [-3, -2, -3.2],
           'splatAlphaRemovalThreshold': 20,
-        }]);
-    abortablePromise.then(() => {
+        }
+    ])
+    .then(() => {
         console.log("Done");
     })
     .catch((error) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "gaussian-splats-3d",
-    "version": "0.1.3",
+    "version": "0.1.9",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "gaussian-splats-3d",
-            "version": "0.1.3",
+            "version": "0.1.9",
             "license": "MIT",
             "dependencies": {
                 "@rollup/plugin-terser": "0.4.4",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
         "type": "git",
         "url": "https://github.com/mkkellogg/GaussianSplat3D"
     },
-    "version": "0.1.3",
+    "version": "0.1.9",
     "description": "Three.js-based 3D Gaussian splat viewer",
     "main": "src/index.js",
     "author": "Mark Kellogg",

--- a/src/AbortablePromise.js
+++ b/src/AbortablePromise.js
@@ -1,0 +1,70 @@
+/**
+ * AbortablePromise: A quick & dirty wrapper for JavaScript's Promise class that allows the underlying
+ * asynchronous operation to be cancelled. It is only meant for simple situations where no promise
+ * chaining or merging occurs. It needs a significant amount of work to truly replicate the full
+ * functionality of JavaScript's Promise class. Look at Util.fetchWithProgress() for example usage.
+ */
+export class AbortablePromise {
+
+    constructor(promiseFunc, abortHandler) {
+
+        let promiseResolve;
+        let promiseReject;
+        this.promise = new Promise((resolve, reject) => {
+            promiseResolve = resolve.bind(this);
+            promiseReject = reject.bind(this);
+        });
+
+        const resolve = (...args) => {
+            promiseResolve(...args);
+        };
+
+        const reject = (error) => {
+            promiseReject(error);
+        };
+
+        promiseFunc(resolve.bind(this), reject.bind(this));
+        this.abortHandler = abortHandler;
+    }
+
+    then(onResolve) {
+        return new AbortablePromise((resolve, reject) => {
+            this.promise = this.promise
+            .then((...args) => {
+                const promiseLike = onResolve(...args);
+                if (promiseLike instanceof Promise || promiseLike instanceof AbortablePromise) {
+                    this.promise = promiseLike.then((...args) => {
+                        resolve(...args);
+                    })
+                } else {
+                    resolve(...args);
+                }  
+            });
+        }, this.abortHandler);
+    }
+
+    catch(onFail) {
+        return new AbortablePromise((resolve, reject) => {
+            this.promise = this.promise
+            .catch((error) => {
+                reject(error);
+            });
+        }, this.abortHandler);
+    }
+
+    abort() {
+        if (this.abortHandler) this.abortHandler();
+    }
+
+    static resolve(data) {
+        return new AbortablePromise((resolve) => {
+            resolve(data);
+        });
+    }
+
+    static reject(error) {
+        return new AbortablePromise((resolve, reject) => {
+            reject(error);
+        });
+    }
+}

--- a/src/DropInViewer.js
+++ b/src/DropInViewer.js
@@ -27,60 +27,60 @@ export class DropInViewer extends THREE.Group {
     }
 
     /**
-     * Load a splat scene into the viewer.
+     * Add a single splat scene to the viewer.
      * @param {string} path Path to splat scene to be loaded
      * @param {object} options {
      *
      *         splatAlphaRemovalThreshold: Ignore any splats with an alpha less than the specified
-     *                                     value (valid range: 0 - 255). Defaults to 1.
+     *                                     value (valid range: 0 - 255), defaults to 1
      *
      *         showLoadingSpinner:         Display a loading spinner while the scene is loading, defaults to true
      *
-     *         position (Array<number>):   Position of the scene, acts as an offset from its default position.
-     *                                     Defaults to [0, 0, 0]
+     *         position (Array<number>):   Position of the scene, acts as an offset from its default position, defaults to [0, 0, 0]
      *
-     *         rotation (Array<number>):   Rotation of the scene represented as a quaternion.
-     *                                     Defaults to [0, 0, 0, 1]
+     *         rotation (Array<number>):   Rotation of the scene represented as a quaternion, defaults to [0, 0, 0, 1]
      *
      *         scale (Array<number>):      Scene's scale, defaults to [1, 1, 1]
      *
      *         onProgress:                 Function to be called as file data are received
      *
      * }
-     * @return {Promise}
+     * @return {AbortablePromise}
      */
     addSceneFromFile(path, options = {}) {
         if (options.showLoadingSpinner !== false) options.showLoadingSpinner = true;
-        return this.viewer.loadFile(path, options).then(() => {
+        const loadPromise = this.viewer.loadFile(path, options);
+        loadPromise.then(() => {
             this.add(this.viewer.splatMesh);
         });
+        return loadPromise;
     }
 
     /**
-     * Load multiple splat scenes into the viewer.
-     * @param {Array<object>} files Array of per-file options: {
+     * Add multiple splat scenes to the viewer.
+     * @param {Array<object>} files Array of per-scene options: {
      *
      *         path: Path to splat scene to be loaded
      *
      *         splatAlphaRemovalThreshold: Ignore any splats with an alpha less than the specified
-     *                                     value (valid range: 0 - 255). Defaults to 1.
+     *                                     value (valid range: 0 - 255), defaults to 1
      *
-     *         position (Array<number>):   Position of the scene, acts as an offset from its default position.
-     *                                     Defaults to [0, 0, 0]
+     *         position (Array<number>):   Position of the scene, acts as an offset from its default position, defaults to [0, 0, 0]
      *
-     *         rotation (Array<number>):   Rotation of the scene represented as a quaternion.
-     *                                     Defaults to [0, 0, 0, 1]
+     *         rotation (Array<number>):   Rotation of the scene represented as a quaternion, defaults to [0, 0, 0, 1]
      *
      *         scale (Array<number>):      Scene's scale, defaults to [1, 1, 1]
      * }
      * @param {boolean} showLoadingSpinner Display a loading spinner while the scene is loading, defaults to true
-     * @return {Promise}
+     * @return {AbortablePromise}
      */
     addScenesFromFiles(files, showLoadingSpinner) {
         if (showLoadingSpinner !== false) showLoadingSpinner = true;
-        return this.viewer.loadFiles(files, showLoadingSpinner).then(() => {
+        const loadPromise = this.viewer.loadFiles(files, showLoadingSpinner);
+        loadPromise.then(() => {
             this.add(this.viewer.splatMesh);
         });
+        return loadPromise;
     }
 
     static onBeforeRender(viewer, renderer, scene, camera) {

--- a/src/PlyLoader.js
+++ b/src/PlyLoader.js
@@ -1,6 +1,5 @@
 import { PlyParser } from './PlyParser.js';
 import { fetchWithProgress } from './Util.js';
-import { AbortablePromise } from './AbortablePromise.js';
 
 export class PlyLoader {
 
@@ -9,18 +8,12 @@ export class PlyLoader {
     }
 
     loadFromURL(fileName, onProgress, compressionLevel, minimumAlpha, blockSize, bucketSize) {
-        const fetchPromise = fetchWithProgress(fileName, onProgress);
-        return new AbortablePromise((resolve, reject) => {
-            fetchPromise.then((plyFileData) => {
-                const plyParser = new PlyParser(plyFileData);
-                const splatBuffer = plyParser.parseToSplatBuffer(compressionLevel, minimumAlpha, blockSize, bucketSize);
-                this.splatBuffer = splatBuffer;
-                resolve(splatBuffer);
-            })
-            .catch((err) => {
-                reject(err);
-            });
-        }, fetchPromise.abortHandler);
+        return fetchWithProgress(fileName, onProgress).then((plyFileData) => {
+            const plyParser = new PlyParser(plyFileData);
+            const splatBuffer = plyParser.parseToSplatBuffer(compressionLevel, minimumAlpha, blockSize, bucketSize);
+            this.splatBuffer = splatBuffer;
+            return splatBuffer;
+        });
     }
 
 }

--- a/src/SplatLoader.js
+++ b/src/SplatLoader.js
@@ -2,6 +2,7 @@ import * as THREE from 'three';
 import { SplatBuffer } from './SplatBuffer.js';
 import { SplatCompressor } from './SplatCompressor.js';
 import { fetchWithProgress } from './Util.js';
+import { AbortablePromise } from './AbortablePromise.js';
 
 export class SplatLoader {
 
@@ -23,9 +24,9 @@ export class SplatLoader {
     }
 
     loadFromURL(fileName, onProgress, compressionLevel, minimumAlpha, blockSize, bucketSize) {
-        return new Promise((resolve, reject) => {
-            fetchWithProgress(fileName, onProgress)
-            .then((bufferData) => {
+        const fetchPromise = fetchWithProgress(fileName, onProgress);
+        return new AbortablePromise((resolve, reject) => {
+            fetchPromise.then((bufferData) => {
                 let splatBuffer;
                 if (SplatLoader.isCustomSplatFormat(fileName)) {
                     splatBuffer = new SplatBuffer(bufferData);
@@ -39,7 +40,7 @@ export class SplatLoader {
             .catch((err) => {
                 reject(err);
             });
-        });
+        }, fetchPromise.abortHandler);
     }
 
     static parseStandardSplatToUncompressedSplatArray(inBuffer) {

--- a/src/SplatMesh.js
+++ b/src/SplatMesh.js
@@ -336,7 +336,7 @@ export class SplatMesh extends THREE.Mesh {
             splatMesh.getSplatColor(splatIndex, splatColor);
             const splatBufferIndex = splatMesh.getSplatBufferIndexForSplat(splatIndex);
             const splatBufferOptions = splatMesh.splatBufferOptions[splatBufferIndex];
-            return splatColor.w > (splatBufferOptions.splatAlphaRemovalThreshold || 1);
+            return splatColor.w >= (splatBufferOptions.splatAlphaRemovalThreshold || 1);
         });
         console.timeEnd('SplatTree build');
 

--- a/src/SplatMesh.js
+++ b/src/SplatMesh.js
@@ -3,6 +3,7 @@ import { SplatTree } from './splattree/SplatTree.js';
 import { uintEncodedFloat, rgbaToInteger } from './Util.js';
 
 const dummyGeometry = new THREE.BufferGeometry();
+const dummyMaterial = new THREE.MeshBasicMaterial();
 
 /**
  * SplatMesh: Container for one or more SplatBuffer instances, abstracting them into a single unified container for
@@ -11,7 +12,7 @@ const dummyGeometry = new THREE.BufferGeometry();
 export class SplatMesh extends THREE.Mesh {
 
     constructor(halfPrecisionCovariancesOnGPU = false, devicePixelRatio = 1, enableDistancesComputationOnGPU = true) {
-        super(dummyGeometry, null);
+        super(dummyGeometry, dummyMaterial);
         this.renderer = undefined;
         this.halfPrecisionCovariancesOnGPU = halfPrecisionCovariancesOnGPU;
         this.devicePixelRatio = devicePixelRatio;
@@ -36,13 +37,13 @@ export class SplatMesh extends THREE.Mesh {
     }
 
     /**
-     * Build the Three.js material that is used to render the splats scene.
+     * Build the Three.js material that is used to render the splats.
      * @return {THREE.ShaderMaterial}
      */
     static buildMaterial() {
 
         // Contains the code to project 3D covariance to 2D and from there calculate the quad (using the eigen vectors of the
-        // 2D covariance) that is ultimately rasterized.
+        // 2D covariance) that is ultimately rasterized
         const vertexShaderSource = `
             precision highp float;
             #include <common>
@@ -225,7 +226,7 @@ export class SplatMesh extends THREE.Mesh {
     }
 
     /**
-     * Build the Three.js geometry that will be used to render the splats scene. The geometry is instanced and is made up of
+     * Build the Three.js geometry that will be used to render the splats. The geometry is instanced and is made up of
      * vertices for a single quad as well as an attribute buffer for the splat indexes.
      * @param {number} maxSplatCount The maximum number of splats that the geometry will need to accomodate
      * @return {THREE.InstancedBufferGeometry}
@@ -264,11 +265,9 @@ export class SplatMesh extends THREE.Mesh {
      * a given splat buffer's position, scale, and orientation relative to the others.
      * @param {Array<object>} splatBufferOptions Array of options objects: {
      *
-     *         position (Array<number>):   Position of the scene, acts as an offset from its default position.
-     *                                     Defaults to [0, 0, 0]
+     *         position (Array<number>):   Position of the scene, acts as an offset from its default position, defaults to [0, 0, 0]
      *
-     *         rotation (Array<number>):   Rotation of the scene represented as a quaternion.
-     *                                     Defaults to [0, 0, 0, 1]
+     *         rotation (Array<number>):   Rotation of the scene represented as a quaternion, defaults to [0, 0, 0, 1]
      *
      *         scale (Array<number>):      Scene's scale, defaults to [1, 1, 1]
      * }
@@ -359,6 +358,7 @@ export class SplatMesh extends THREE.Mesh {
         console.log(`SplatTree leaves with splats:${leavesWithVertices}`);
         avgSplatCount = avgSplatCount / nodeCount;
         console.log(`Avg splat count per node: ${avgSplatCount}`);
+        console.log(`Total splat count: ${splatMesh.getSplatCount()}`);
         return splatTree;
     }
 
@@ -368,13 +368,11 @@ export class SplatMesh extends THREE.Mesh {
      * @param {Array<object>} splatBufferOptions Dynamic options for each splat buffer {
      *
      *         splatAlphaRemovalThreshold: Ignore any splats with an alpha less than the specified
-     *                                     value (valid range: 0 - 255). Defaults to 1.
+     *                                     value (valid range: 0 - 255), defaults to 1
      *
-     *         position (Array<number>):   Position of the scene, acts as an offset from its default position.
-     *                                     Defaults to [0, 0, 0]
+     *         position (Array<number>):   Position of the scene, acts as an offset from its default position, defaults to [0, 0, 0]
      *
-     *         rotation (Array<number>):   Rotation of the scene represented as a quaternion.
-     *                                     Defaults to [0, 0, 0, 1]
+     *         rotation (Array<number>):   Rotation of the scene represented as a quaternion, defaults to [0, 0, 0, 1]
      *
      *         scale (Array<number>):      Scene's scale, defaults to [1, 1, 1]
      *

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import { SplatCompressor } from './SplatCompressor.js';
 import { Viewer } from './Viewer.js';
 import { DropInViewer } from './DropInViewer.js';
 import { OrbitControls } from './OrbitControls.js';
+import { AbortablePromise } from './AbortablePromise.js';
 
 export {
     PlyParser,
@@ -15,5 +16,6 @@ export {
     SplatCompressor,
     Viewer,
     DropInViewer,
-    OrbitControls
+    OrbitControls,
+    AbortablePromise
 };


### PR DESCRIPTION
- Added `AbortablePromise` which allows for the cancellation of the underlying asynchronous event for a `Promise`.
- Lots of cleanup