### PR TITLE
fix: use includes for .ply search instead of endswith

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,4 @@ dist
 build
 demo
 node_modules
-
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 dist
 build
+demo
 node_modules
+
+.DS_Store

--- a/src/Viewer.js
+++ b/src/Viewer.js
@@ -530,7 +530,7 @@ export class Viewer {
         };
         if (SplatLoader.isFileSplatFormat(path)) {
             return new SplatLoader().loadFromURL(path, downloadProgress, 0, splatAlphaRemovalThreshold);
-        } else if (path.endsWith('.ply')) {
+        } else if (path.includes('.ply')) {
             return new PlyLoader().loadFromURL(path, downloadProgress, 0, splatAlphaRemovalThreshold);
         } else {
             return AbortablePromise.reject(new Error(`Viewer::loadFileToSplatBuffer -> File format not supported: ${path}`));


### PR DESCRIPTION
My ply files have a token in the query parameters so I cannot search for a path that ends with .ply. I have to use includes. 