### PR TITLE
General updates & bugfixes

### DIFF
--- a/demo/dropin.html
+++ b/demo/dropin.html
@@ -91,9 +91,7 @@
     const threeScene = setupThreeScene();
     const controls = setupControls(camera, renderer);
 
-    const viewer = new GaussianSplats3D.DropInViewer({
-      'dynamicScene': false
-    });
+    const viewer = new GaussianSplats3D.DropInViewer();
     viewer.addSplatScenes([
         {
           'path': 'assets/data/garden/garden.ksplat',
@@ -107,7 +105,7 @@
           'splatAlphaRemovalThreshold': 20,
         }
       ], true);
-      threeScene.add(viewer);
+    threeScene.add(viewer);
 
     requestAnimationFrame(update);
     function update() {

--- a/demo/dropin.html
+++ b/demo/dropin.html
@@ -91,7 +91,9 @@
     const threeScene = setupThreeScene();
     const controls = setupControls(camera, renderer);
 
-    const viewer = new GaussianSplats3D.DropInViewer();
+    const viewer = new GaussianSplats3D.DropInViewer({
+      'dynamicScene': false
+    });
     viewer.addSplatScenes([
         {
           'path': 'assets/data/garden/garden.ksplat',

--- a/demo/dynamic_scenes.html
+++ b/demo/dynamic_scenes.html
@@ -52,39 +52,41 @@
         }
     ], true).then(() => {
       viewer.start();
+
+      const bonsaiCount = 2;
+      const bonsaiStartIndex = 1;
+      const rotationAxis = new THREE.Vector3(0, -1, -0.6).normalize();
+      const baseQuaternion = new THREE.Quaternion(-0.147244, -0.07617, 0.14106, 0.9760);
+      const rotationQuaternion = new THREE.Quaternion();
+      const quaternion = new THREE.Quaternion();
+      const orbitCenter = new THREE.Vector3(0.416161, 1.385, 1.145);
+      const horizontalOffsetVector = new THREE.Vector3();
+      const position = new THREE.Vector3();
+      const scale = new THREE.Vector3(1.25, 1.25, 1.25);
+
+      let startTime = performance.now() / 1000.0;
+      requestAnimationFrame(update);
+      function update() {
+        requestAnimationFrame(update);
+        const timeDelta = performance.now() / 1000.0 - startTime;
+        for (let i = bonsaiStartIndex; i < bonsaiStartIndex + bonsaiCount; i++) {
+          const angle = timeDelta * 0.25 + (Math.PI * 2) * (i /bonsaiCount);
+          const height = Math.cos(timeDelta + (Math.PI * 2) * (i / bonsaiCount)) * 0.5 + 3;
+
+          rotationQuaternion.setFromAxisAngle(rotationAxis, angle);
+          horizontalOffsetVector.set(3, 0, 0).applyQuaternion(rotationQuaternion);
+          position.copy(rotationAxis).multiplyScalar(height).add(horizontalOffsetVector).add(orbitCenter);
+          quaternion.copy(baseQuaternion).premultiply(rotationQuaternion);
+
+          const splatScene = viewer.getSplatScene(i);
+          splatScene.position.copy(position);
+          splatScene.quaternion.copy(quaternion);
+          splatScene.scale.copy(scale);
+        }
+      }
+
     })
 
-    const bonsaiCount = 2;
-    const bonsaiStartIndex = 1;
-    const rotationAxis = new THREE.Vector3(0, -1, -0.6).normalize();
-    const baseQuaternion = new THREE.Quaternion(-0.147244, -0.07617, 0.14106, 0.9760);
-    const rotationQuaternion = new THREE.Quaternion();
-    const quaternion = new THREE.Quaternion();
-    const orbitCenter = new THREE.Vector3(0.416161, 1.385, 1.145);
-    const horizontalOffsetVector = new THREE.Vector3();
-    const position = new THREE.Vector3();
-    const scale = new THREE.Vector3(1.25, 1.25, 1.25);
-
-    let startTime = performance.now() / 1000.0;
-    requestAnimationFrame(update);
-    function update() {
-      requestAnimationFrame(update);
-      const timeDelta = performance.now() / 1000.0 - startTime;
-      for (let i = bonsaiStartIndex; i < bonsaiStartIndex + bonsaiCount; i++) {
-        const angle = timeDelta * 0.25 + (Math.PI * 2) / i;
-        const height = Math.cos(timeDelta + (Math.PI * 2) / i) * 0.5 + 3;
-
-        rotationQuaternion.setFromAxisAngle(rotationAxis, angle);
-        horizontalOffsetVector.set(3, 0, 0).applyQuaternion(rotationQuaternion);
-        position.copy(rotationAxis).multiplyScalar(height).add(horizontalOffsetVector).add(orbitCenter);
-        quaternion.copy(baseQuaternion).premultiply(rotationQuaternion);
-
-        const splatScene = viewer.getSplatScene(i);
-        splatScene.position.copy(position);
-        splatScene.quaternion.copy(quaternion);
-        splatScene.scale.copy(scale);
-      }
-    }
   </script>
 </body>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@mkkellogg/gaussian-splats-3d",
-    "version": "0.2.1",
+    "version": "0.2.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@mkkellogg/gaussian-splats-3d",
-            "version": "0.2.1",
+            "version": "0.2.2",
             "license": "MIT",
             "dependencies": {
                 "@rollup/plugin-terser": "0.4.4",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
         "type": "git",
         "url": "https://github.com/mkkellogg/GaussianSplat3D"
     },
-    "version": "0.2.1",
+    "version": "0.2.2",
     "description": "Three.js-based 3D Gaussian splat viewer",
     "module": "build/gaussian-splats-3d.module.js",
     "main": "build/gaussian-splats-3d.umd.cjs",

--- a/src/SceneFormat.js
+++ b/src/SceneFormat.js
@@ -1,0 +1,5 @@
+export const SceneFormat = {
+    'Splat': 0,
+    'KSplat': 1,
+    'Ply': 2
+};

--- a/src/SceneHelper.js
+++ b/src/SceneHelper.js
@@ -1,20 +1,23 @@
 import * as THREE from 'three';
 import { ArrowHelper } from './ArrowHelper.js';
+import { disposeAllMeshes } from './Util.js';
 
 export class SceneHelper {
 
     constructor(threeScene) {
         this.threeScene = threeScene;
         this.splatRenderTarget = null;
-        this.renderTargetCopyMaterial = null;
         this.renderTargetCopyQuad = null;
         this.renderTargetCopyCamera = null;
         this.meshCursor = null;
         this.focusMarker = null;
         this.controlPlane = null;
+        this.debugRoot = null;
+        this.secondaryDebugRoot = null;
     }
 
     updateSplatRenderTargetForRenderDimensions(width, height) {
+        this.destroySplatRendertarget();
         this.splatRenderTarget = new THREE.WebGLRenderTarget(width, height, {
             format: THREE.RGBAFormat,
             stencilBuffer: false,
@@ -24,6 +27,12 @@ export class SceneHelper {
         this.splatRenderTarget.depthTexture = new THREE.DepthTexture(width, height);
         this.splatRenderTarget.depthTexture.format = THREE.DepthFormat;
         this.splatRenderTarget.depthTexture.type = THREE.UnsignedIntType;
+    }
+
+    destroySplatRendertarget() {
+        if (this.splatRenderTarget) {
+            this.splatRenderTarget = null;
+        }
     }
 
     setupRenderTargetCopyObjects() {
@@ -37,7 +46,7 @@ export class SceneHelper {
                 'value': null
             },
         };
-        this.renderTargetCopyMaterial = new THREE.ShaderMaterial({
+        const renderTargetCopyMaterial = new THREE.ShaderMaterial({
             vertexShader: `
                 varying vec2 vUv;
                 void main() {
@@ -68,9 +77,16 @@ export class SceneHelper {
             blendDst: THREE.OneMinusSrcAlphaFactor,
             blendDstAlpha: THREE.OneMinusSrcAlphaFactor
         });
-        this.renderTargetCopyMaterial.extensions.fragDepth = true;
-        this.renderTargetCopyQuad = new THREE.Mesh(new THREE.PlaneGeometry(2, 2), this.renderTargetCopyMaterial);
+        renderTargetCopyMaterial.extensions.fragDepth = true;
+        this.renderTargetCopyQuad = new THREE.Mesh(new THREE.PlaneGeometry(2, 2), renderTargetCopyMaterial);
         this.renderTargetCopyCamera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1);
+    }
+
+    destroyRenderTargetCopyObjects() {
+        if (this.renderTargetCopyQuad) {
+            disposeAllMeshes(this.renderTargetCopyQuad);
+            this.renderTargetCopyQuad = null;
+        }
     }
 
     setupMeshCursor() {
@@ -103,10 +119,7 @@ export class SceneHelper {
 
     destroyMeshCursor() {
         if (this.meshCursor) {
-            this.meshCursor.children.forEach((child) => {
-                child.geometry.dispose();
-                child.material.dispose();
-            });
+            disposeAllMeshes(this.meshCursor);
             this.threeScene.remove(this.meshCursor);
             this.meshCursor = null;
         }
@@ -133,8 +146,14 @@ export class SceneHelper {
             focusMarkerMaterial.depthTest = false;
             focusMarkerMaterial.depthWrite = false;
             focusMarkerMaterial.transparent = true;
-            const sphereMesh = new THREE.Mesh(sphereGeometry, focusMarkerMaterial);
-            this.focusMarker = sphereMesh;
+            this.focusMarker = new THREE.Mesh(sphereGeometry, focusMarkerMaterial);
+        }
+    }
+
+    destroyFocusMarker() {
+        if (this.focusMarker) {
+            disposeAllMeshes(this.focusMarker);
+            this.focusMarker = null;
         }
     }
 
@@ -170,27 +189,36 @@ export class SceneHelper {
     }
 
     setupControlPlane() {
-        const planeGeometry = new THREE.PlaneGeometry(1, 1);
-        planeGeometry.rotateX(-Math.PI / 2);
-        const planeMaterial = new THREE.MeshBasicMaterial({color: 0xffffff});
-        planeMaterial.transparent = true;
-        planeMaterial.opacity = 0.6;
-        planeMaterial.depthTest = false;
-        planeMaterial.depthWrite = false;
-        planeMaterial.side = THREE.DoubleSide;
-        const planeMesh = new THREE.Mesh(planeGeometry, planeMaterial);
+        if (!this.controlPlane) {
+            const planeGeometry = new THREE.PlaneGeometry(1, 1);
+            planeGeometry.rotateX(-Math.PI / 2);
+            const planeMaterial = new THREE.MeshBasicMaterial({color: 0xffffff});
+            planeMaterial.transparent = true;
+            planeMaterial.opacity = 0.6;
+            planeMaterial.depthTest = false;
+            planeMaterial.depthWrite = false;
+            planeMaterial.side = THREE.DoubleSide;
+            const planeMesh = new THREE.Mesh(planeGeometry, planeMaterial);
 
-        const arrowDir = new THREE.Vector3(0, 1, 0);
-        arrowDir.normalize();
-        const arrowOrigin = new THREE.Vector3(0, 0, 0);
-        const arrowLength = 0.5;
-        const arrowRadius = 0.01;
-        const arrowColor = 0x00dd00;
-        const arrowHelper = new ArrowHelper(arrowDir, arrowOrigin, arrowLength, arrowRadius, arrowColor, 0.1, 0.03);
+            const arrowDir = new THREE.Vector3(0, 1, 0);
+            arrowDir.normalize();
+            const arrowOrigin = new THREE.Vector3(0, 0, 0);
+            const arrowLength = 0.5;
+            const arrowRadius = 0.01;
+            const arrowColor = 0x00dd00;
+            const arrowHelper = new ArrowHelper(arrowDir, arrowOrigin, arrowLength, arrowRadius, arrowColor, 0.1, 0.03);
 
-        this.controlPlane = new THREE.Object3D();
-        this.controlPlane.add(planeMesh);
-        this.controlPlane.add(arrowHelper);
+            this.controlPlane = new THREE.Object3D();
+            this.controlPlane.add(planeMesh);
+            this.controlPlane.add(arrowHelper);
+        }
+    }
+
+    destroyControlPlane() {
+        if (this.controlPlane) {
+            disposeAllMeshes(this.controlPlane);
+            this.controlPlane = null;
+        }
     }
 
     setControlPlaneVisibility(visible) {
@@ -215,6 +243,17 @@ export class SceneHelper {
         this.secondaryDebugRoot = this.createSecondaryDebugMeshes();
         this.threeScene.add(this.debugRoot);
         this.threeScene.add(this.secondaryDebugRoot);
+    }
+
+    destroyDebugMeshes() {
+        for (let debugRoot of [this.debugRoot, this.secondaryDebugRoot]) {
+            if (debugRoot) {
+                disposeAllMeshes(debugRoot);
+                this.threeScene.remove(debugRoot);
+            }
+        }
+        this.debugRoot = null;
+        this.secondaryDebugRoot = null;
     }
 
     createDebugMeshes(renderOrder) {
@@ -394,5 +433,14 @@ export class SceneHelper {
         });
 
         return material;
+    }
+
+    dispose() {
+        this.destroyMeshCursor();
+        this.destroyFocusMarker();
+        this.destroyDebugMeshes();
+        this.destroyControlPlane();
+        this.destroyRenderTargetCopyObjects();
+        this.destroySplatRendertarget();
     }
 }

--- a/src/SplatBuffer.js
+++ b/src/SplatBuffer.js
@@ -1,7 +1,5 @@
 import * as THREE from 'three';
 
-let fbf;
-
 /**
  * SplatBuffer: Container for splat data from a single scene/file and capable of (mediocre) compression.
  */
@@ -63,8 +61,6 @@ export class SplatBuffer {
         this.bytesPerRotation = SplatBuffer.CompressionLevels[this.compressionLevel].BytesPerRotation;
 
         this.bytesPerSplat = this.bytesPerCenter + this.bytesPerScale + this.bytesPerColor + this.bytesPerRotation;
-
-        fbf = this.fbf.bind(this);
 
         this.linkBufferArrays();
     }
@@ -130,10 +126,12 @@ export class SplatBuffer {
 
         return function(index, outScale, outRotation, transform) {
             const scaleBase = index * SplatBuffer.ScaleComponentCount;
-            outScale.set(fbf(this.scaleArray[scaleBase]), fbf(this.scaleArray[scaleBase + 1]), fbf(this.scaleArray[scaleBase + 2]));
+            outScale.set(this.fbf(this.scaleArray[scaleBase]),
+                         this.fbf(this.scaleArray[scaleBase + 1]),
+                         this.fbf(this.scaleArray[scaleBase + 2]));
             const rotationBase = index * SplatBuffer.RotationComponentCount;
-            outRotation.set(fbf(this.rotationArray[rotationBase + 1]), fbf(this.rotationArray[rotationBase + 2]),
-                            fbf(this.rotationArray[rotationBase + 3]), fbf(this.rotationArray[rotationBase]));
+            outRotation.set(this.fbf(this.rotationArray[rotationBase + 1]), this.fbf(this.rotationArray[rotationBase + 2]),
+                            this.fbf(this.rotationArray[rotationBase + 3]), this.fbf(this.rotationArray[rotationBase]));
             if (transform) {
                 scaleMatrix.makeScale(outScale.x, outScale.y, outScale.z);
                 rotationMatrix.makeRotationFromQuaternion(outRotation);
@@ -195,15 +193,17 @@ export class SplatBuffer {
 
         for (let i = 0; i < splatCount; i++) {
             const scaleBase = i * SplatBuffer.ScaleComponentCount;
-            scale.set(fbf(this.scaleArray[scaleBase]), fbf(this.scaleArray[scaleBase + 1]), fbf(this.scaleArray[scaleBase + 2]));
+            scale.set(this.fbf(this.scaleArray[scaleBase]),
+                      this.fbf(this.scaleArray[scaleBase + 1]),
+                      this.fbf(this.scaleArray[scaleBase + 2]));
             tempMatrix4.makeScale(scale.x, scale.y, scale.z);
             scaleMatrix.setFromMatrix4(tempMatrix4);
 
             const rotationBase = i * SplatBuffer.RotationComponentCount;
-            rotation.set(fbf(this.rotationArray[rotationBase + 1]),
-                         fbf(this.rotationArray[rotationBase + 2]),
-                         fbf(this.rotationArray[rotationBase + 3]),
-                         fbf(this.rotationArray[rotationBase]));
+            rotation.set(this.fbf(this.rotationArray[rotationBase + 1]),
+                         this.fbf(this.rotationArray[rotationBase + 2]),
+                         this.fbf(this.rotationArray[rotationBase + 3]),
+                         this.fbf(this.rotationArray[rotationBase]));
             tempMatrix4.makeRotationFromQuaternion(rotation);
             rotationMatrix.setFromMatrix4(tempMatrix4);
 

--- a/src/SplatLoader.js
+++ b/src/SplatLoader.js
@@ -2,6 +2,7 @@ import * as THREE from 'three';
 import { SplatBuffer } from './SplatBuffer.js';
 import { SplatCompressor } from './SplatCompressor.js';
 import { fetchWithProgress } from './Util.js';
+import { SceneFormat } from './SceneFormat.js';
 
 export class SplatLoader {
 
@@ -22,10 +23,11 @@ export class SplatLoader {
         return fileName.endsWith('.splat');
     }
 
-    loadFromURL(fileName, onProgress, compressionLevel, minimumAlpha, blockSize, bucketSize) {
+    loadFromURL(fileName, onProgress, compressionLevel, minimumAlpha, blockSize, bucketSize, format) {
         return fetchWithProgress(fileName, onProgress).then((bufferData) => {
+            const isCustomSplatFormat = format === SceneFormat.KSplat || SplatLoader.isCustomSplatFormat(fileName);
             let splatBuffer;
-            if (SplatLoader.isCustomSplatFormat(fileName)) {
+            if (isCustomSplatFormat) {
                 splatBuffer = new SplatBuffer(bufferData);
             } else {
                 const splatCompressor = new SplatCompressor(compressionLevel, minimumAlpha, blockSize, bucketSize);

--- a/src/SplatMesh.js
+++ b/src/SplatMesh.js
@@ -456,7 +456,7 @@ export class SplatMesh extends THREE.Mesh {
 
         const newScenes = SplatMesh.buildScenes(splatBuffers, sceneOptions);
         if (keepSceneTransforms) {
-            for (let i = 0; i < this.scenes.length; i++) {
+            for (let i = 0; i < this.scenes.length && i < newScenes.length; i++) {
                 const newScene = newScenes[i];
                 const existingScene = this.getScene(i);
                 newScene.copyTransformData(existingScene);
@@ -1290,11 +1290,10 @@ export class SplatMesh extends THREE.Mesh {
      * @return {SplatScene}
      */
     getScene(sceneIndex) {
-        let scene = this.scenes[sceneIndex];
-        if (!scene) {
-            this.scenes[sceneIndex] = scene = SplatMesh.createScene();
+        if (sceneIndex < 0 || sceneIndex >= this.scenes.length) {
+            throw new Error('SplatMesh::getScene() -> Invalid scene index.');
         }
-        return scene;
+        return this.scenes[sceneIndex];
     }
 
     getSplatBufferForSplat(globalIndex) {

--- a/src/SplatMesh.js
+++ b/src/SplatMesh.js
@@ -147,21 +147,31 @@ export class SplatMesh extends THREE.Mesh {
                 vec3 cov3D_M11_M12_M13 = vec3(sampledCovarianceA.rg, sampledCovarianceB.r);
                 vec3 cov3D_M22_M23_M33 = vec3(sampledCovarianceB.g, sampledCovarianceC.rg);
 
-                // Compute the 2D covariance matrix from the upper-right portion of the 3D covariance matrix
+                // Construct the 3D covariance matrix
                 mat3 Vrk = mat3(
                     cov3D_M11_M12_M13.x, cov3D_M11_M12_M13.y, cov3D_M11_M12_M13.z,
                     cov3D_M11_M12_M13.y, cov3D_M22_M23_M33.x, cov3D_M22_M23_M33.y,
                     cov3D_M11_M12_M13.z, cov3D_M22_M23_M33.y, cov3D_M22_M23_M33.z
                 );
+
+                // Construct the Jacobian of the affine approximation of the projection matrix. It will be used to transform the
+                // 3D covariance matrix instead of using the actual projection matrix because that transformation would
+                // require a non-linear component (perspective division) which would yield a non-gaussian result. (This assumes
+                // the current projection is a perspective projection).
                 float s = 1.0 / (viewCenter.z * viewCenter.z);
                 mat3 J = mat3(
                     focal.x / viewCenter.z, 0., -(focal.x * viewCenter.x) * s,
                     0., focal.y / viewCenter.z, -(focal.y * viewCenter.y) * s,
                     0., 0., 0.
                 );
+
+                // Concatenate the projection approximation with the model-view transformation
                 mat3 W = transpose(mat3(transformModelViewMatrix));
                 mat3 T = W * J;
+
+                // Transform the 3D covariance matrix (Vrk) to compute the 2D covariance matrix
                 mat3 cov2Dm = transpose(T) * Vrk * T;
+
                 cov2Dm[0][0] += 0.3;
                 cov2Dm[1][1] += 0.3;
 

--- a/src/Util.js
+++ b/src/Util.js
@@ -112,3 +112,19 @@ export const clamp = function(val, min, max) {
 export const getCurrentTime = function() {
     return performance.now() / 1000;
 };
+
+export const disposeAllMeshes = (object3D) => {
+    if (object3D.geometry) {
+        object3D.geometry.dispose();
+        object3D.geometry = null;
+    }
+    if (object3D.material) {
+        object3D.material.dispose();
+        object3D.material = null;
+    }
+    if (object3D.children) {
+        for (let child of object3D.children) {
+            disposeAllMeshes(child);
+        }
+    }
+};

--- a/src/Viewer.js
+++ b/src/Viewer.js
@@ -286,20 +286,8 @@ export class Viewer {
         const renderDimensions = new THREE.Vector2();
         const toNewFocalPoint = new THREE.Vector3();
         const outHits = [];
-        const tempCenter = new THREE.Vector3();
-        const tempColor = new THREE.Vector4();
-        const tempScale = new THREE.Vector3();
-        const tempRotation = new THREE.Quaternion();
-        let debugMesh;
 
         return function() {
-            if (!debugMesh) {
-                const geometry = new THREE.SphereGeometry(1, 32, 32);
-                const material = new THREE.MeshBasicMaterial({'color': 0xff0000});
-                debugMesh = new THREE.Mesh(geometry, material);
-                debugMesh.visible = false;
-                this.threeScene.add(debugMesh);
-            }
             if (!this.transitioningCameraTarget) {
                 this.getRenderDimensions(renderDimensions);
                 outHits.length = 0;
@@ -307,15 +295,6 @@ export class Viewer {
                 this.raycaster.intersectSplatMesh(this.splatMesh, outHits);
                 if (outHits.length > 0) {
                     const hit = outHits[0];
-                    const splatIndex = hit.splatIndex;
-                    this.splatMesh.getSplatCenter(splatIndex, tempCenter, false);
-                    this.splatMesh.getSplatColor(splatIndex, tempColor, false);
-                    this.splatMesh.getSplatScaleAndRotation(splatIndex, tempScale, tempRotation, false);
-                    debugMesh.position.copy(tempCenter);
-                    debugMesh.scale.copy(tempScale).multiplyScalar(2 * Math.log10(tempColor.w));
-                    debugMesh.quaternion.copy(tempRotation);
-                    debugMesh.visible = true;
-
                     const intersectionPoint = hit.origin;
                     toNewFocalPoint.copy(intersectionPoint).sub(this.camera.position);
                     if (toNewFocalPoint.length() > MINIMUM_DISTANCE_TO_NEW_FOCAL_POINT) {

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ import { Viewer } from './Viewer.js';
 import { DropInViewer } from './DropInViewer.js';
 import { OrbitControls } from './OrbitControls.js';
 import { AbortablePromise } from './AbortablePromise.js';
+import { SceneFormat } from './SceneFormat.js';
 
 export {
     PlyParser,
@@ -17,5 +18,6 @@ export {
     Viewer,
     DropInViewer,
     OrbitControls,
-    AbortablePromise
+    AbortablePromise,
+    SceneFormat
 };

--- a/src/raycaster/Hit.js
+++ b/src/raycaster/Hit.js
@@ -6,12 +6,14 @@ export class Hit {
         this.origin = new THREE.Vector3();
         this.normal = new THREE.Vector3();
         this.distance = 0;
+        this.splatIndex = 0;
     }
 
-    set(origin, normal, distance) {
+    set(origin, normal, distance, splatIndex) {
         this.origin.copy(origin);
         this.normal.copy(normal);
         this.distance = distance;
+        this.splatIndex = splatIndex;
     }
 
     clone() {
@@ -19,6 +21,7 @@ export class Hit {
         hitClone.origin.copy(this.origin);
         hitClone.normal.copy(this.normal);
         hitClone.distance = this.distance;
+        hitClone.splatIndex = this.splatIndex;
         return hitClone;
     }
 


### PR DESCRIPTION
- Added `Viewer.dispose()` to explicitly dispose of resources directly and indirectly held by the viewer
- Added parameter to scene loading functions to force splat scene format (ply, splat, or ksplat)
- Cleaned up raycasting code, now supports raycasting directly at splat ellipsoids
- Fixed dynamic scenes demo to begin altering scene transforms after the viewer is ready