### PR TITLE
Add built-in WebXR support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ When I started, web-based viewers were already available -- A WebGL-based viewer
 - Viewer can import `.ply` files, `.splat` files, or my custom compressed `.ksplat` files
 - Users can convert `.ply` or `.splat` files to the `.ksplat` file format
 - Allows a Three.js scene or object group to be rendered along with the splats
+- Built-in WebXR support
 - Focus on optimization:
     - Splats culled prior to sorting & rendering using a custom octree
     - WASM splat sort: Implemented in C++ using WASM SIMD instructions
@@ -34,8 +35,7 @@ This is still very much a work in progress! There are several things that still 
   - Properly incorporate spherical harmonics data to achieve view dependent lighting effects
   - Continue optimizing CPU-based splat sort - maybe try an incremental sort of some kind?
   - Add editing mode, allowing users to modify scene and export changes
-  - Add WebXR compatibility
-  - Support very large scenes and/or multiple splat files
+  - Support very large scenes
 
 ## Online demo
 [https://projects.markkellogg.org/threejs/demo_gaussian_splats_3d.php](https://projects.markkellogg.org/threejs/demo_gaussian_splats_3d.php)
@@ -256,7 +256,9 @@ const viewer = new GaussianSplats3D.Viewer({
     'gpuAcceleratedSort': true,
     'halfPrecisionCovariancesOnGPU': true,
     'sharedMemoryForWorkers': true,
-    'integerBasedSort': true
+    'integerBasedSort': true,
+    'dynamicScene': false,
+    'webXRMode': GaussianSplats3D.WebXRMode.None
 });
 viewer.addSplatScene('<path to .ply, .ksplat, or .splat file>')
 .then(() => {
@@ -285,6 +287,7 @@ Advanced `Viewer` parameters
 | `sharedMemoryForWorkers` | Tells the viewer to use shared memory via a `SharedArrayBuffer` to transfer data to and from the sorting web worker. If set to `false`, it is recommended that `gpuAcceleratedSort` be set to `false` as well. Defaults to `true`.
 | `integerBasedSort` | Tells the sorting web worker to use the integer versions of relevant data to compute the distance of splats from the camera. Since integer arithmetic is faster than floating point, this reduces sort time. However it can result in integer overflows in larger scenes so it should only be used for small scenes. Defaults to `true`.
 | `dynamicScene` | Tells the viewer to not make any optimizations that depend on the scene being static. Additionally all splat data retrieved from the viewer's splat mesh will not have their respective scene transform applied to them by default.
+| `webXRMode` | Tells the viewer whether or not to enable built-in Web VR or Web AR. Valid values are defined in the `WebXRMode` enum: `None`, `VR`, and `AR`. Defaults to `None`.
 <br>
 
 ### Creating KSPLAT files

--- a/demo/vr.html
+++ b/demo/vr.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="x-ua-compatible" content="ie=edge">
+  <title>3D Gaussian Splat Demo - VR Garden</title>
+  <script type="text/javascript" src="js/util.js"></script>
+  <script type="importmap">
+    {
+        "imports": {
+            "three": "./lib/three.module.js",
+            "@mkkellogg/gaussian-splats-3d": "./lib/gaussian-splats-3d.module.js"
+        }
+    }
+  </script>
+  <style>
+
+    body {
+      background-color: #000000;
+      height: 100vh;
+      margin: 0px;
+    }
+
+  </style>
+
+</head>
+
+<body>
+  <script type="module">
+    import * as GaussianSplats3D from '@mkkellogg/gaussian-splats-3d';
+    import * as THREE from 'three';
+    const viewer = new GaussianSplats3D.Viewer({
+      'initialCameraPosition': [0.33667, 0.52980, 1.77169],
+      'initialCameraLookAt': [0.20786, -0.68154, -0.27311],
+      'webXRMode': GaussianSplats3D.WebXRMode.VR
+    });
+    let path = 'assets/data/bonsai/bonsai.ksplat';
+    viewer.addSplatScene(path, {
+        'rotation': new THREE.Quaternion().setFromUnitVectors(new THREE.Vector3(0.01933, -0.75830, -0.65161).normalize(), new THREE.Vector3(0, 1, 0)).toArray(),
+        'scale': [0.25, 0.25, 0.25]
+    })
+    .then(() => {
+        viewer.start();
+    });
+  </script>
+</body>
+
+</html>

--- a/demo/vr.html
+++ b/demo/vr.html
@@ -32,14 +32,17 @@
     import * as GaussianSplats3D from '@mkkellogg/gaussian-splats-3d';
     import * as THREE from 'three';
     const viewer = new GaussianSplats3D.Viewer({
-      'initialCameraPosition': [0.33667, 0.52980, 1.77169],
+      'initialCameraPosition': [-0.77493, -0.54359, 1.63199],
       'initialCameraLookAt': [0.20786, -0.68154, -0.27311],
-      'webXRMode': GaussianSplats3D.WebXRMode.VR
+      'webXRMode': GaussianSplats3D.WebXRMode.AR,
+      'gpuAcceleratesSort': false,
+      'sharedMemoryForWebWorkers': false
     });
     let path = 'assets/data/bonsai/bonsai.ksplat';
     viewer.addSplatScene(path, {
         'rotation': new THREE.Quaternion().setFromUnitVectors(new THREE.Vector3(0.01933, -0.75830, -0.65161).normalize(), new THREE.Vector3(0, 1, 0)).toArray(),
-        'scale': [0.25, 0.25, 0.25]
+        'scale': [0.25, 0.25, 0.25],
+        'position': [0, 1, 0]
     })
     .then(() => {
         viewer.start();

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,27 +8,26 @@
             "name": "@mkkellogg/gaussian-splats-3d",
             "version": "0.2.2",
             "license": "MIT",
-            "dependencies": {
-                "@rollup/plugin-terser": "0.4.4",
-                "@rollup/pluginutils": "5.0.5",
-                "http-server": "14.1.1",
-                "install": "0.13.0",
-                "npm-watch": "0.11.0",
-                "rollup": "3.28.1",
-                "three": "0.160.0"
-            },
             "devDependencies": {
                 "@babel/core": "7.22.0",
                 "@babel/eslint-parser": "7.22.11",
                 "@babel/plugin-proposal-class-properties": "7.18.6",
                 "@babel/preset-env": "7.22.10",
+                "@rollup/plugin-terser": "0.4.4",
+                "@rollup/pluginutils": "5.0.5",
                 "babel-loader": "9.1.3",
                 "eslint": "8.47.0",
                 "eslint-config-google": "0.14.0",
                 "file-loader": "6.2.0",
+                "http-server": "14.1.1",
+                "npm-watch": "0.11.0",
                 "prettier": "3.0.2",
                 "prettier-eslint": "15.0.1",
+                "rollup": "3.28.1",
                 "url-loader": "4.1.1"
+            },
+            "peerDependencies": {
+                "three": ">=0.155.0"
             }
         },
         "node_modules/@aashutoshrathi/word-wrap": {
@@ -1846,6 +1845,7 @@
             "version": "0.3.3",
             "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
             "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
+            "dev": true,
             "dependencies": {
                 "@jridgewell/set-array": "^1.0.1",
                 "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -1859,6 +1859,7 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
             "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
+            "dev": true,
             "engines": {
                 "node": ">=6.0.0"
             }
@@ -1867,6 +1868,7 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
             "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+            "dev": true,
             "engines": {
                 "node": ">=6.0.0"
             }
@@ -1875,6 +1877,7 @@
             "version": "0.3.5",
             "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.5.tgz",
             "integrity": "sha512-UTYAUj/wviwdsMfzoSJspJxbkH5o1snzwX0//0ENX1u/55kkZZkcTZP6u9bwKGkv+dkk9at4m1Cpt0uY80kcpQ==",
+            "dev": true,
             "dependencies": {
                 "@jridgewell/gen-mapping": "^0.3.0",
                 "@jridgewell/trace-mapping": "^0.3.9"
@@ -1883,12 +1886,14 @@
         "node_modules/@jridgewell/sourcemap-codec": {
             "version": "1.4.15",
             "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-            "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
+            "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+            "dev": true
         },
         "node_modules/@jridgewell/trace-mapping": {
             "version": "0.3.19",
             "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.19.tgz",
             "integrity": "sha512-kf37QtfW+Hwx/buWGMPcR60iF9ziHa6r/CZJIHbmcm4+0qrXiVdxegAH0F6yddEVQ7zdkjcGCgCzUu+BcbhQxw==",
+            "dev": true,
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.1.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -1942,6 +1947,7 @@
             "version": "0.4.4",
             "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-0.4.4.tgz",
             "integrity": "sha512-XHeJC5Bgvs8LfukDwWZp7yeqin6ns8RTl2B9avbejt6tZqsqvVoWI7ZTQrcNsfKEDWBTnTxM8nMDkO2IFFbd0A==",
+            "dev": true,
             "dependencies": {
                 "serialize-javascript": "^6.0.1",
                 "smob": "^1.0.0",
@@ -1963,6 +1969,7 @@
             "version": "5.0.5",
             "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.5.tgz",
             "integrity": "sha512-6aEYR910NyP73oHiJglti74iRyOwgFU4x3meH/H8OJx6Ry0j6cOVZ5X/wTvub7G7Ao6qaHBEaNsV3GLJkSsF+Q==",
+            "dev": true,
             "dependencies": {
                 "@types/estree": "^1.0.0",
                 "estree-walker": "^2.0.2",
@@ -2004,7 +2011,8 @@
         "node_modules/@types/estree": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.2.tgz",
-            "integrity": "sha512-VeiPZ9MMwXjO32/Xu7+OwflfmeoRwkE/qzndw42gGtgJwZopBnzy2gD//NN1+go1mADzkDcqf/KnFRSjTJ8xJA=="
+            "integrity": "sha512-VeiPZ9MMwXjO32/Xu7+OwflfmeoRwkE/qzndw42gGtgJwZopBnzy2gD//NN1+go1mADzkDcqf/KnFRSjTJ8xJA==",
+            "dev": true
         },
         "node_modules/@types/json-schema": {
             "version": "7.0.13",
@@ -2349,12 +2357,14 @@
         "node_modules/abbrev": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-            "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+            "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+            "dev": true
         },
         "node_modules/acorn": {
             "version": "8.10.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
             "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+            "dev": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -2470,6 +2480,7 @@
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
             "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+            "dev": true,
             "dependencies": {
                 "normalize-path": "^3.0.0",
                 "picomatch": "^2.0.4"
@@ -2497,6 +2508,7 @@
             "version": "2.6.4",
             "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
             "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+            "dev": true,
             "dependencies": {
                 "lodash": "^4.17.14"
             }
@@ -2560,12 +2572,14 @@
         "node_modules/balanced-match": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true
         },
         "node_modules/basic-auth": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
             "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+            "dev": true,
             "dependencies": {
                 "safe-buffer": "5.1.2"
             },
@@ -2586,6 +2600,7 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
             "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -2594,6 +2609,7 @@
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -2603,6 +2619,7 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
             "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+            "dev": true,
             "dependencies": {
                 "fill-range": "^7.0.1"
             },
@@ -2645,12 +2662,14 @@
         "node_modules/buffer-from": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-            "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+            "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+            "dev": true
         },
         "node_modules/call-bind": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
             "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+            "dev": true,
             "dependencies": {
                 "function-bind": "^1.1.1",
                 "get-intrinsic": "^1.0.2"
@@ -2706,6 +2725,7 @@
             "version": "3.5.3",
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
             "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+            "dev": true,
             "funding": [
                 {
                     "type": "individual",
@@ -2732,6 +2752,7 @@
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
             "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+            "dev": true,
             "dependencies": {
                 "is-glob": "^4.0.1"
             },
@@ -2767,7 +2788,8 @@
         "node_modules/commander": {
             "version": "2.20.3",
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+            "dev": true
         },
         "node_modules/common-path-prefix": {
             "version": "3.0.0",
@@ -2787,7 +2809,8 @@
         "node_modules/concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+            "dev": true
         },
         "node_modules/convert-source-map": {
             "version": "1.9.0",
@@ -2812,6 +2835,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz",
             "integrity": "sha512-utCYNzRSQIZNPIcGZdQc92UVJYAhtGAteCFg0yRaFm8f0P+CPtyGyHXJcGXnffjCybUCEx3FQ2G7U3/o9eIkVQ==",
+            "dev": true,
             "engines": {
                 "node": ">= 0.4.0"
             }
@@ -3242,7 +3266,8 @@
         "node_modules/estree-walker": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
+            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+            "dev": true
         },
         "node_modules/esutils": {
             "version": "2.0.3",
@@ -3256,7 +3281,8 @@
         "node_modules/eventemitter3": {
             "version": "4.0.7",
             "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-            "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+            "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+            "dev": true
         },
         "node_modules/events": {
             "version": "3.3.0",
@@ -3377,6 +3403,7 @@
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
             "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+            "dev": true,
             "dependencies": {
                 "to-regex-range": "^5.0.1"
             },
@@ -3440,6 +3467,7 @@
             "version": "1.15.3",
             "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
             "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
+            "dev": true,
             "funding": [
                 {
                     "type": "individual",
@@ -3465,6 +3493,7 @@
             "version": "2.3.3",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
             "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+            "dev": true,
             "hasInstallScript": true,
             "optional": true,
             "os": [
@@ -3477,7 +3506,8 @@
         "node_modules/function-bind": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+            "dev": true
         },
         "node_modules/gensync": {
             "version": "1.0.0-beta.2",
@@ -3492,6 +3522,7 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
             "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
+            "dev": true,
             "dependencies": {
                 "function-bind": "^1.1.1",
                 "has": "^1.0.3",
@@ -3587,6 +3618,7 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
             "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+            "dev": true,
             "dependencies": {
                 "function-bind": "^1.1.1"
             },
@@ -3619,6 +3651,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
             "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+            "dev": true,
             "engines": {
                 "node": ">=4"
             }
@@ -3627,6 +3660,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
             "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+            "dev": true,
             "engines": {
                 "node": ">= 0.4"
             },
@@ -3638,6 +3672,7 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
             "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+            "dev": true,
             "engines": {
                 "node": ">= 0.4"
             },
@@ -3649,6 +3684,7 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
             "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+            "dev": true,
             "bin": {
                 "he": "bin/he"
             }
@@ -3657,6 +3693,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
             "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+            "dev": true,
             "dependencies": {
                 "whatwg-encoding": "^2.0.0"
             },
@@ -3668,6 +3705,7 @@
             "version": "1.18.1",
             "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
             "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
+            "dev": true,
             "dependencies": {
                 "eventemitter3": "^4.0.0",
                 "follow-redirects": "^1.0.0",
@@ -3681,6 +3719,7 @@
             "version": "14.1.1",
             "resolved": "https://registry.npmjs.org/http-server/-/http-server-14.1.1.tgz",
             "integrity": "sha512-+cbxadF40UXd9T01zUHgA+rlo2Bg1Srer4+B4NwIHdaGxAGGv59nYRnGGDJ9LBk7alpS0US+J+bLLdQOOkJq4A==",
+            "dev": true,
             "dependencies": {
                 "basic-auth": "^2.0.1",
                 "chalk": "^4.1.2",
@@ -3707,6 +3746,7 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
             "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
             "dependencies": {
                 "color-convert": "^2.0.1"
             },
@@ -3721,6 +3761,7 @@
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
             "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dev": true,
             "dependencies": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -3736,6 +3777,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
             "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
             "dependencies": {
                 "color-name": "~1.1.4"
             },
@@ -3746,12 +3788,14 @@
         "node_modules/http-server/node_modules/color-name": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true
         },
         "node_modules/http-server/node_modules/has-flag": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
             "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -3760,6 +3804,7 @@
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
             "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dev": true,
             "dependencies": {
                 "has-flag": "^4.0.0"
             },
@@ -3771,6 +3816,7 @@
             "version": "0.6.3",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
             "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+            "dev": true,
             "dependencies": {
                 "safer-buffer": ">= 2.1.2 < 3.0.0"
             },
@@ -3790,7 +3836,8 @@
         "node_modules/ignore-by-default": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
-            "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA=="
+            "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
+            "dev": true
         },
         "node_modules/import-fresh": {
             "version": "3.3.0",
@@ -3839,20 +3886,14 @@
         "node_modules/inherits": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-        },
-        "node_modules/install": {
-            "version": "0.13.0",
-            "resolved": "https://registry.npmjs.org/install/-/install-0.13.0.tgz",
-            "integrity": "sha512-zDml/jzr2PKU9I8J/xyZBQn8rPCAY//UOYNmR01XwNwyfhEWObo2SWfSl1+0tm1u6PhxLwDnfsT/6jB7OUxqFA==",
-            "engines": {
-                "node": ">= 0.10"
-            }
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "dev": true
         },
         "node_modules/is-binary-path": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
             "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+            "dev": true,
             "dependencies": {
                 "binary-extensions": "^2.0.0"
             },
@@ -3876,6 +3917,7 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
             "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -3884,6 +3926,7 @@
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
             "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+            "dev": true,
             "dependencies": {
                 "is-extglob": "^2.1.1"
             },
@@ -3895,6 +3938,7 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
             "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+            "dev": true,
             "engines": {
                 "node": ">=0.12.0"
             }
@@ -4086,7 +4130,8 @@
         "node_modules/lodash": {
             "version": "4.17.21",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+            "dev": true
         },
         "node_modules/lodash.debounce": {
             "version": "4.0.8",
@@ -4220,6 +4265,7 @@
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
             "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+            "dev": true,
             "bin": {
                 "mime": "cli.js"
             },
@@ -4252,6 +4298,7 @@
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
             "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -4263,6 +4310,7 @@
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
             "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+            "dev": true,
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -4271,6 +4319,7 @@
             "version": "0.5.6",
             "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
             "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+            "dev": true,
             "dependencies": {
                 "minimist": "^1.2.6"
             },
@@ -4281,7 +4330,8 @@
         "node_modules/ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+            "dev": true
         },
         "node_modules/natural-compare": {
             "version": "1.4.0",
@@ -4306,6 +4356,7 @@
             "version": "2.0.22",
             "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.22.tgz",
             "integrity": "sha512-B8YqaKMmyuCO7BowF1Z1/mkPqLk6cs/l63Ojtd6otKjMx47Dq1utxfRxcavH1I7VSaL8n5BUaoutadnsX3AAVQ==",
+            "dev": true,
             "dependencies": {
                 "chokidar": "^3.5.2",
                 "debug": "^3.2.7",
@@ -4333,6 +4384,7 @@
             "version": "3.2.7",
             "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
             "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+            "dev": true,
             "dependencies": {
                 "ms": "^2.1.1"
             }
@@ -4341,6 +4393,7 @@
             "version": "5.7.2",
             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
             "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+            "dev": true,
             "bin": {
                 "semver": "bin/semver"
             }
@@ -4349,6 +4402,7 @@
             "version": "1.0.10",
             "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
             "integrity": "sha512-NWmpvLSqUrgrAC9HCuxEvb+PSloHpqVu+FqcO4eeF2h5qYRhA7ev6KvelyQAKtegUbC6RypJnlEOhd8vloNKYg==",
+            "dev": true,
             "dependencies": {
                 "abbrev": "1"
             },
@@ -4363,6 +4417,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
             "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -4371,6 +4426,7 @@
             "version": "0.11.0",
             "resolved": "https://registry.npmjs.org/npm-watch/-/npm-watch-0.11.0.tgz",
             "integrity": "sha512-wAOd0moNX2kSA2FNvt8+7ORwYaJpQ1ZoWjUYdb1bBCxq4nkWuU0IiJa9VpVxrj5Ks+FGXQd62OC/Bjk0aSr+dg==",
+            "dev": true,
             "dependencies": {
                 "nodemon": "^2.0.7",
                 "through2": "^4.0.2"
@@ -4383,6 +4439,7 @@
             "version": "1.12.3",
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
             "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
+            "dev": true,
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -4400,6 +4457,7 @@
             "version": "1.5.2",
             "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
             "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+            "dev": true,
             "bin": {
                 "opener": "bin/opener-bin.js"
             }
@@ -4515,6 +4573,7 @@
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
             "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "dev": true,
             "engines": {
                 "node": ">=8.6"
             },
@@ -4623,6 +4682,7 @@
             "version": "1.0.32",
             "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.32.tgz",
             "integrity": "sha512-on2ZJVVDXRADWE6jnQaX0ioEylzgBpQk8r55NE4wjXW1ZxO+BgDlY6DXwj20i0V8eB4SenDQ00WEaxfiIQPcxg==",
+            "dev": true,
             "dependencies": {
                 "async": "^2.6.4",
                 "debug": "^3.2.7",
@@ -4636,6 +4696,7 @@
             "version": "3.2.7",
             "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
             "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+            "dev": true,
             "dependencies": {
                 "ms": "^2.1.1"
             }
@@ -4717,7 +4778,8 @@
         "node_modules/pstree.remy": {
             "version": "1.1.8",
             "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
-            "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w=="
+            "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
+            "dev": true
         },
         "node_modules/punycode": {
             "version": "2.3.0",
@@ -4732,6 +4794,7 @@
             "version": "6.11.2",
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.2.tgz",
             "integrity": "sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==",
+            "dev": true,
             "dependencies": {
                 "side-channel": "^1.0.4"
             },
@@ -4766,6 +4829,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
             "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+            "dev": true,
             "dependencies": {
                 "safe-buffer": "^5.1.0"
             }
@@ -4774,6 +4838,7 @@
             "version": "3.6.2",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
             "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+            "dev": true,
             "dependencies": {
                 "inherits": "^2.0.3",
                 "string_decoder": "^1.1.1",
@@ -4787,6 +4852,7 @@
             "version": "3.6.0",
             "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
             "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+            "dev": true,
             "dependencies": {
                 "picomatch": "^2.2.1"
             },
@@ -4883,7 +4949,8 @@
         "node_modules/requires-port": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-            "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
+            "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+            "dev": true
         },
         "node_modules/resolve": {
             "version": "1.22.6",
@@ -4940,6 +5007,7 @@
             "version": "3.28.1",
             "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.28.1.tgz",
             "integrity": "sha512-R9OMQmIHJm9znrU3m3cpE8uhN0fGdXiawME7aZIpQqvpS/85+Vt1Hq1/yVIcYfOmaQiHjvXkQAoJukvLpau6Yw==",
+            "dev": true,
             "bin": {
                 "rollup": "dist/bin/rollup"
             },
@@ -4977,12 +5045,14 @@
         "node_modules/safe-buffer": {
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "dev": true
         },
         "node_modules/safer-buffer": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+            "dev": true
         },
         "node_modules/schema-utils": {
             "version": "4.2.0",
@@ -5040,7 +5110,8 @@
         "node_modules/secure-compare": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/secure-compare/-/secure-compare-3.0.1.tgz",
-            "integrity": "sha512-AckIIV90rPDcBcglUwXPF3kg0P0qmPsPXAj6BBEENQE1p5yA1xfmDJzfi1Tappj37Pv2mVbKpL3Z1T+Nn7k1Qw=="
+            "integrity": "sha512-AckIIV90rPDcBcglUwXPF3kg0P0qmPsPXAj6BBEENQE1p5yA1xfmDJzfi1Tappj37Pv2mVbKpL3Z1T+Nn7k1Qw==",
+            "dev": true
         },
         "node_modules/semver": {
             "version": "6.3.1",
@@ -5055,6 +5126,7 @@
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.1.tgz",
             "integrity": "sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==",
+            "dev": true,
             "dependencies": {
                 "randombytes": "^2.1.0"
             }
@@ -5084,6 +5156,7 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
             "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+            "dev": true,
             "dependencies": {
                 "call-bind": "^1.0.0",
                 "get-intrinsic": "^1.0.2",
@@ -5097,6 +5170,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-1.1.0.tgz",
             "integrity": "sha512-VpsrsJSUcJEseSbMHkrsrAVSdvVS5I96Qo1QAQ4FxQ9wXFcB+pjj7FB7/us9+GcgfW4ziHtYMc1J0PLczb55mg==",
+            "dev": true,
             "dependencies": {
                 "semver": "~7.0.0"
             },
@@ -5108,6 +5182,7 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
             "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
+            "dev": true,
             "bin": {
                 "semver": "bin/semver.js"
             }
@@ -5124,12 +5199,14 @@
         "node_modules/smob": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/smob/-/smob-1.4.1.tgz",
-            "integrity": "sha512-9LK+E7Hv5R9u4g4C3p+jjLstaLe11MDsL21UpYaCNmapvMkYhqCV4A/f/3gyH8QjMyh6l68q9xC85vihY9ahMQ=="
+            "integrity": "sha512-9LK+E7Hv5R9u4g4C3p+jjLstaLe11MDsL21UpYaCNmapvMkYhqCV4A/f/3gyH8QjMyh6l68q9xC85vihY9ahMQ==",
+            "dev": true
         },
         "node_modules/source-map": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -5138,6 +5215,7 @@
             "version": "0.5.21",
             "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
             "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+            "dev": true,
             "dependencies": {
                 "buffer-from": "^1.0.0",
                 "source-map": "^0.6.0"
@@ -5147,6 +5225,7 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
             "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+            "dev": true,
             "dependencies": {
                 "safe-buffer": "~5.2.0"
             }
@@ -5155,6 +5234,7 @@
             "version": "5.2.1",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
             "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -5207,6 +5287,7 @@
             "version": "5.5.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
             "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+            "dev": true,
             "dependencies": {
                 "has-flag": "^3.0.0"
             },
@@ -5240,6 +5321,7 @@
             "version": "5.20.0",
             "resolved": "https://registry.npmjs.org/terser/-/terser-5.20.0.tgz",
             "integrity": "sha512-e56ETryaQDyebBwJIWYB2TT6f2EZ0fL0sW/JRXNMN26zZdKi2u/E/5my5lG6jNxym6qsrVXfFRmOdV42zlAgLQ==",
+            "dev": true,
             "dependencies": {
                 "@jridgewell/source-map": "^0.3.3",
                 "acorn": "^8.8.2",
@@ -5316,12 +5398,14 @@
         "node_modules/three": {
             "version": "0.160.0",
             "resolved": "https://registry.npmjs.org/three/-/three-0.160.0.tgz",
-            "integrity": "sha512-DLU8lc0zNIPkM7rH5/e1Ks1Z8tWCGRq6g8mPowdDJpw1CFBJMU7UoJjC6PefXW7z//SSl0b2+GCw14LB+uDhng=="
+            "integrity": "sha512-DLU8lc0zNIPkM7rH5/e1Ks1Z8tWCGRq6g8mPowdDJpw1CFBJMU7UoJjC6PefXW7z//SSl0b2+GCw14LB+uDhng==",
+            "peer": true
         },
         "node_modules/through2": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
             "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
+            "dev": true,
             "dependencies": {
                 "readable-stream": "3"
             }
@@ -5339,6 +5423,7 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
             "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+            "dev": true,
             "dependencies": {
                 "is-number": "^7.0.0"
             },
@@ -5350,6 +5435,7 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.0.tgz",
             "integrity": "sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==",
+            "dev": true,
             "dependencies": {
                 "nopt": "~1.0.10"
             },
@@ -5418,7 +5504,8 @@
         "node_modules/undefsafe": {
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
-            "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA=="
+            "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
+            "dev": true
         },
         "node_modules/unicode-canonical-property-names-ecmascript": {
             "version": "2.0.0",
@@ -5464,6 +5551,7 @@
             "version": "0.5.0",
             "resolved": "https://registry.npmjs.org/union/-/union-0.5.0.tgz",
             "integrity": "sha512-N6uOhuW6zO95P3Mel2I2zMsbsanvvtgn6jVqJv4vbVcz/JN0OkL9suomjQGmWtxJQXOCqUJvquc1sMeNz/IwlA==",
+            "dev": true,
             "dependencies": {
                 "qs": "^6.4.0"
             },
@@ -5513,7 +5601,8 @@
         "node_modules/url-join": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
-            "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="
+            "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
+            "dev": true
         },
         "node_modules/url-loader": {
             "version": "4.1.1",
@@ -5563,7 +5652,8 @@
         "node_modules/util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-            "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+            "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+            "dev": true
         },
         "node_modules/vue-eslint-parser": {
             "version": "8.3.0",
@@ -5754,6 +5844,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
             "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+            "dev": true,
             "dependencies": {
                 "iconv-lite": "0.6.3"
             },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@mkkellogg/gaussian-splats-3d",
-    "version": "0.2.2",
+    "version": "0.2.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@mkkellogg/gaussian-splats-3d",
-            "version": "0.2.2",
+            "version": "0.2.3",
             "license": "MIT",
             "devDependencies": {
                 "@babel/core": "7.22.0",
@@ -27,7 +27,7 @@
                 "url-loader": "4.1.1"
             },
             "peerDependencies": {
-                "three": ">=0.155.0"
+                "three": ">=0.160.0"
             }
         },
         "node_modules/@aashutoshrathi/word-wrap": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
                 "install": "0.13.0",
                 "npm-watch": "0.11.0",
                 "rollup": "3.28.1",
-                "three": "0.155.0"
+                "three": "0.160.0"
             },
             "devDependencies": {
                 "@babel/core": "7.22.0",
@@ -5314,9 +5314,9 @@
             "dev": true
         },
         "node_modules/three": {
-            "version": "0.155.0",
-            "resolved": "https://registry.npmjs.org/three/-/three-0.155.0.tgz",
-            "integrity": "sha512-sNgCYmDijnIqkD/bMfk+1pHg3YzsxW7V2ChpuP6HCQ8NiZr3RufsXQr8M3SSUMjW4hG+sUk7YbyuY0DncaDTJQ=="
+            "version": "0.160.0",
+            "resolved": "https://registry.npmjs.org/three/-/three-0.160.0.tgz",
+            "integrity": "sha512-DLU8lc0zNIPkM7rH5/e1Ks1Z8tWCGRq6g8mPowdDJpw1CFBJMU7UoJjC6PefXW7z//SSl0b2+GCw14LB+uDhng=="
         },
         "node_modules/through2": {
             "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
         "install": "0.13.0",
         "npm-watch": "0.11.0",
         "rollup": "3.28.1",
-        "three": "0.155.0"
+        "three": "0.160.0"
     },
     "files": [
         "build/gaussian-splats-3d.umd.cjs",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
         "splatting",
         "3D",
         "gaussian",
-        "webgl"
+        "webgl",
+        "javascript"
     ],
     "devDependencies": {
         "@babel/core": "7.22.0",
@@ -53,21 +54,20 @@
         "@babel/plugin-proposal-class-properties": "7.18.6",
         "@babel/preset-env": "7.22.10",
         "babel-loader": "9.1.3",
+        "@rollup/plugin-terser": "0.4.4",
+        "@rollup/pluginutils": "5.0.5",
         "eslint": "8.47.0",
         "eslint-config-google": "0.14.0",
         "file-loader": "6.2.0",
+        "http-server": "14.1.1",
+        "npm-watch": "0.11.0",
         "prettier": "3.0.2",
         "prettier-eslint": "15.0.1",
+        "rollup": "3.28.1",
         "url-loader": "4.1.1"
     },
-    "dependencies": {
-        "@rollup/plugin-terser": "0.4.4",
-        "@rollup/pluginutils": "5.0.5",
-        "http-server": "14.1.1",
-        "install": "0.13.0",
-        "npm-watch": "0.11.0",
-        "rollup": "3.28.1",
-        "three": "0.160.0"
+    "peerDependencies": {
+        "three": ">=0.155.0"
     },
     "files": [
         "build/gaussian-splats-3d.umd.cjs",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
         "type": "git",
         "url": "https://github.com/mkkellogg/GaussianSplat3D"
     },
-    "version": "0.2.2",
+    "version": "0.2.3",
     "description": "Three.js-based 3D Gaussian splat viewer",
     "module": "build/gaussian-splats-3d.module.js",
     "main": "build/gaussian-splats-3d.umd.cjs",
@@ -67,7 +67,7 @@
         "url-loader": "4.1.1"
     },
     "peerDependencies": {
-        "three": ">=0.155.0"
+        "three": ">=0.160.0"
     },
     "files": [
         "build/gaussian-splats-3d.umd.cjs",

--- a/src/DropInViewer.js
+++ b/src/DropInViewer.js
@@ -92,6 +92,10 @@ export class DropInViewer extends THREE.Group {
         return this.viewer.getSplatScene(sceneIndex);
     }
 
+    dispose() {
+        return this.viewer.dispose();
+    }
+
     static onBeforeRender(viewer, renderer, threeScene, camera) {
         viewer.update(renderer, camera);
     }

--- a/src/OrbitControls.js
+++ b/src/OrbitControls.js
@@ -1,3 +1,17 @@
+/*
+Copyright © 2010-2024 three.js authors & Mark Kellogg
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+*/
+
 import {
     EventDispatcher,
     MOUSE,

--- a/src/SplatMesh.js
+++ b/src/SplatMesh.js
@@ -206,7 +206,7 @@ export class SplatMesh extends THREE.Mesh {
                 float traceOver2 = 0.5 * trace;
                 float term2 = sqrt(max(0.1f, traceOver2 * traceOver2 - D));
                 float eigenValue1 = traceOver2 + term2;
-	            float eigenValue2 = traceOver2 - term2;
+                float eigenValue2 = traceOver2 - term2;
 
                 float transparentAdjust = step(1.0 / 255.0, vColor.a);
                 eigenValue2 = eigenValue2 * transparentAdjust; // hide splat if alpha is zero

--- a/src/Viewer.js
+++ b/src/Viewer.js
@@ -206,9 +206,9 @@ export class Viewer {
         }
 
         if (this.webXRMode) {
-            if(this.webXRMode === WebXRMode.VR) {
+            if (this.webXRMode === WebXRMode.VR) {
                 this.rootElement.appendChild(VRButton.createButton(this.renderer));
-            } else if(this.webXRMode === WebXRMode.AR) {
+            } else if (this.webXRMode === WebXRMode.AR) {
                 this.rootElement.appendChild(ARButton.createButton(this.renderer));
             }
             this.renderer.xr.enabled = true;
@@ -803,7 +803,7 @@ export class Viewer {
     }
 
     selfDrivenUpdate() {
-        if (this.selfDrivenMode) {
+        if (this.selfDrivenMode && !this.webXRMode) {
             this.requestFrameId = requestAnimationFrame(this.selfDrivenUpdateFunc);
         }
         this.update();
@@ -1000,9 +1000,11 @@ export class Viewer {
             const cameraPosString = `[${cameraPos.x.toFixed(5)}, ${cameraPos.y.toFixed(5)}, ${cameraPos.z.toFixed(5)}]`;
             this.infoPanelCells.cameraPosition.innerHTML = cameraPosString;
 
+            if (this.controls) {
             const cameraLookAt = this.controls.target;
             const cameraLookAtString = `[${cameraLookAt.x.toFixed(5)}, ${cameraLookAt.y.toFixed(5)}, ${cameraLookAt.z.toFixed(5)}]`;
             this.infoPanelCells.cameraLookAt.innerHTML = cameraLookAtString;
+            }
 
             const cameraUp = this.camera.up;
             const cameraUpString = `[${cameraUp.x.toFixed(5)}, ${cameraUp.y.toFixed(5)}, ${cameraUp.z.toFixed(5)}]`;

--- a/src/Viewer.js
+++ b/src/Viewer.js
@@ -183,8 +183,8 @@ export class Viewer {
         if (!this.usingExternalCamera) {
             this.camera = new THREE.PerspectiveCamera(THREE_CAMERA_FOV, renderDimensions.x / renderDimensions.y, 0.1, 500);
             this.camera.position.copy(this.initialCameraPosition);
-            this.camera.lookAt(this.initialCameraLookAt);
             this.camera.up.copy(this.cameraUp).normalize();
+            this.camera.lookAt(this.initialCameraLookAt);
         }
 
         if (!this.usingExternalRenderer) {
@@ -205,13 +205,15 @@ export class Viewer {
             this.rootElement.appendChild(this.renderer.domElement);
         }
 
-        if (options.WebXRMode) {
-            if(options.webXRMode === WebXRMode.VR) {
+        if (this.webXRMode) {
+            if(this.webXRMode === WebXRMode.VR) {
                 this.rootElement.appendChild(VRButton.createButton(this.renderer));
-            } else if(options.webXRMode === WebXRMode.AR) {
+            } else if(this.webXRMode === WebXRMode.AR) {
                 this.rootElement.appendChild(ARButton.createButton(this.renderer));
             }
             this.renderer.xr.enabled = true;
+            this.camera.up.copy(this.cameraUp).normalize();
+            this.camera.lookAt(this.initialCameraLookAt);
         }
 
         this.threeScene = this.threeScene || new THREE.Scene();
@@ -220,7 +222,7 @@ export class Viewer {
         this.sceneHelper.setupFocusMarker();
         this.sceneHelper.setupControlPlane();
 
-        if (this.useBuiltInControls) {
+        if (this.useBuiltInControls && this.webXRMode === WebXRMode.None) {
             this.controls = new OrbitControls(this.camera, this.renderer.domElement);
             this.controls.listenToKeyEvents(window);
             this.controls.rotateSpeed = 0.5;

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import { DropInViewer } from './DropInViewer.js';
 import { OrbitControls } from './OrbitControls.js';
 import { AbortablePromise } from './AbortablePromise.js';
 import { SceneFormat } from './SceneFormat.js';
+import { WebXRMode } from './webxr/WebXRMode.js';
 
 export {
     PlyParser,
@@ -19,5 +20,6 @@ export {
     DropInViewer,
     OrbitControls,
     AbortablePromise,
-    SceneFormat
+    SceneFormat,
+    WebXRMode
 };

--- a/src/webxr/ARButton.js
+++ b/src/webxr/ARButton.js
@@ -1,230 +1,230 @@
 export class ARButton {
 
-	static createButton( renderer, sessionInit = {} ) {
+    static createButton( renderer, sessionInit = {} ) {
 
-		const button = document.createElement( 'button' );
+        const button = document.createElement( 'button' );
 
-		function showStartAR( /*device*/ ) {
+        function showStartAR( /* device */ ) {
 
-			if ( sessionInit.domOverlay === undefined ) {
+            if ( sessionInit.domOverlay === undefined ) {
 
-				const overlay = document.createElement( 'div' );
-				overlay.style.display = 'none';
-				document.body.appendChild( overlay );
+                const overlay = document.createElement( 'div' );
+                overlay.style.display = 'none';
+                document.body.appendChild( overlay );
 
-				const svg = document.createElementNS( 'http://www.w3.org/2000/svg', 'svg' );
-				svg.setAttribute( 'width', 38 );
-				svg.setAttribute( 'height', 38 );
-				svg.style.position = 'absolute';
-				svg.style.right = '20px';
-				svg.style.top = '20px';
-				svg.addEventListener( 'click', function () {
+                const svg = document.createElementNS( 'http://www.w3.org/2000/svg', 'svg' );
+                svg.setAttribute( 'width', 38 );
+                svg.setAttribute( 'height', 38 );
+                svg.style.position = 'absolute';
+                svg.style.right = '20px';
+                svg.style.top = '20px';
+                svg.addEventListener( 'click', function() {
 
-					currentSession.end();
+                    currentSession.end();
 
-				} );
-				overlay.appendChild( svg );
+                } );
+                overlay.appendChild( svg );
 
-				const path = document.createElementNS( 'http://www.w3.org/2000/svg', 'path' );
-				path.setAttribute( 'd', 'M 12,12 L 28,28 M 28,12 12,28' );
-				path.setAttribute( 'stroke', '#fff' );
-				path.setAttribute( 'stroke-width', 2 );
-				svg.appendChild( path );
+                const path = document.createElementNS( 'http://www.w3.org/2000/svg', 'path' );
+                path.setAttribute( 'd', 'M 12,12 L 28,28 M 28,12 12,28' );
+                path.setAttribute( 'stroke', '#fff' );
+                path.setAttribute( 'stroke-width', 2 );
+                svg.appendChild( path );
 
-				if ( sessionInit.optionalFeatures === undefined ) {
+                if ( sessionInit.optionalFeatures === undefined ) {
 
-					sessionInit.optionalFeatures = [];
+                    sessionInit.optionalFeatures = [];
 
-				}
+                }
 
-				sessionInit.optionalFeatures.push( 'dom-overlay' );
-				sessionInit.domOverlay = { root: overlay };
+                sessionInit.optionalFeatures.push( 'dom-overlay' );
+                sessionInit.domOverlay = { root: overlay };
 
-			}
+            }
 
-			//
+            //
 
-			let currentSession = null;
+            let currentSession = null;
 
-			async function onSessionStarted( session ) {
+            async function onSessionStarted( session ) {
 
-				session.addEventListener( 'end', onSessionEnded );
+                session.addEventListener( 'end', onSessionEnded );
 
-				renderer.xr.setReferenceSpaceType( 'local' );
+                renderer.xr.setReferenceSpaceType( 'local' );
 
-				await renderer.xr.setSession( session );
+                await renderer.xr.setSession( session );
 
-				button.textContent = 'STOP AR';
-				sessionInit.domOverlay.root.style.display = '';
+                button.textContent = 'STOP AR';
+                sessionInit.domOverlay.root.style.display = '';
 
-				currentSession = session;
+                currentSession = session;
 
-			}
+            }
 
-			function onSessionEnded( /*event*/ ) {
+            function onSessionEnded( /* event */ ) {
 
-				currentSession.removeEventListener( 'end', onSessionEnded );
+                currentSession.removeEventListener( 'end', onSessionEnded );
 
-				button.textContent = 'START AR';
-				sessionInit.domOverlay.root.style.display = 'none';
+                button.textContent = 'START AR';
+                sessionInit.domOverlay.root.style.display = 'none';
 
-				currentSession = null;
+                currentSession = null;
 
-			}
+            }
 
-			//
+            //
 
-			button.style.display = '';
+            button.style.display = '';
 
-			button.style.cursor = 'pointer';
-			button.style.left = 'calc(50% - 50px)';
-			button.style.width = '100px';
+            button.style.cursor = 'pointer';
+            button.style.left = 'calc(50% - 50px)';
+            button.style.width = '100px';
 
-			button.textContent = 'START AR';
+            button.textContent = 'START AR';
 
-			button.onmouseenter = function () {
+            button.onmouseenter = function() {
 
-				button.style.opacity = '1.0';
+                button.style.opacity = '1.0';
 
-			};
+            };
 
-			button.onmouseleave = function () {
+            button.onmouseleave = function() {
 
-				button.style.opacity = '0.5';
+                button.style.opacity = '0.5';
 
-			};
+            };
 
-			button.onclick = function () {
+            button.onclick = function() {
 
-				if ( currentSession === null ) {
+                if ( currentSession === null ) {
 
-					navigator.xr.requestSession( 'immersive-ar', sessionInit ).then( onSessionStarted );
+                    navigator.xr.requestSession( 'immersive-ar', sessionInit ).then( onSessionStarted );
 
-				} else {
+                } else {
 
-					currentSession.end();
+                    currentSession.end();
 
-					if ( navigator.xr.offerSession !== undefined ) {
+                    if ( navigator.xr.offerSession !== undefined ) {
 
-						navigator.xr.offerSession( 'immersive-ar', sessionInit )
-							.then( onSessionStarted )
-							.catch( ( err ) => {
+                        navigator.xr.offerSession( 'immersive-ar', sessionInit )
+                            .then( onSessionStarted )
+                            .catch( ( err ) => {
 
-								console.warn( err );
+                                console.warn( err );
 
-							} );
+                            } );
 
-					}
+                    }
 
-				}
+                }
 
-			};
+            };
 
-			if ( navigator.xr.offerSession !== undefined ) {
+            if ( navigator.xr.offerSession !== undefined ) {
 
-				navigator.xr.offerSession( 'immersive-ar', sessionInit )
-					.then( onSessionStarted )
-					.catch( ( err ) => {
+                navigator.xr.offerSession( 'immersive-ar', sessionInit )
+                    .then( onSessionStarted )
+                    .catch( ( err ) => {
 
-						console.warn( err );
+                        console.warn( err );
 
-					} );
+                    } );
 
-			}
+            }
 
-		}
+        }
 
-		function disableButton() {
+        function disableButton() {
 
-			button.style.display = '';
+            button.style.display = '';
 
-			button.style.cursor = 'auto';
-			button.style.left = 'calc(50% - 75px)';
-			button.style.width = '150px';
+            button.style.cursor = 'auto';
+            button.style.left = 'calc(50% - 75px)';
+            button.style.width = '150px';
 
-			button.onmouseenter = null;
-			button.onmouseleave = null;
+            button.onmouseenter = null;
+            button.onmouseleave = null;
 
-			button.onclick = null;
+            button.onclick = null;
 
-		}
+        }
 
-		function showARNotSupported() {
+        function showARNotSupported() {
 
-			disableButton();
+            disableButton();
 
-			button.textContent = 'AR NOT SUPPORTED';
+            button.textContent = 'AR NOT SUPPORTED';
 
-		}
+        }
 
-		function showARNotAllowed( exception ) {
+        function showARNotAllowed( exception ) {
 
-			disableButton();
+            disableButton();
 
-			console.warn( 'Exception when trying to call xr.isSessionSupported', exception );
+            console.warn( 'Exception when trying to call xr.isSessionSupported', exception );
 
-			button.textContent = 'AR NOT ALLOWED';
+            button.textContent = 'AR NOT ALLOWED';
 
-		}
+        }
 
-		function stylizeElement( element ) {
+        function stylizeElement( element ) {
 
-			element.style.position = 'absolute';
-			element.style.bottom = '20px';
-			element.style.padding = '12px 6px';
-			element.style.border = '1px solid #fff';
-			element.style.borderRadius = '4px';
-			element.style.background = 'rgba(0,0,0,0.1)';
-			element.style.color = '#fff';
-			element.style.font = 'normal 13px sans-serif';
-			element.style.textAlign = 'center';
-			element.style.opacity = '0.5';
-			element.style.outline = 'none';
-			element.style.zIndex = '999';
+            element.style.position = 'absolute';
+            element.style.bottom = '20px';
+            element.style.padding = '12px 6px';
+            element.style.border = '1px solid #fff';
+            element.style.borderRadius = '4px';
+            element.style.background = 'rgba(0,0,0,0.1)';
+            element.style.color = '#fff';
+            element.style.font = 'normal 13px sans-serif';
+            element.style.textAlign = 'center';
+            element.style.opacity = '0.5';
+            element.style.outline = 'none';
+            element.style.zIndex = '999';
 
-		}
+        }
 
-		if ( 'xr' in navigator ) {
+        if ( 'xr' in navigator ) {
 
-			button.id = 'ARButton';
-			button.style.display = 'none';
+            button.id = 'ARButton';
+            button.style.display = 'none';
 
-			stylizeElement( button );
+            stylizeElement( button );
 
-			navigator.xr.isSessionSupported( 'immersive-ar' ).then( function ( supported ) {
+            navigator.xr.isSessionSupported( 'immersive-ar' ).then( function( supported ) {
 
-				supported ? showStartAR() : showARNotSupported();
+                supported ? showStartAR() : showARNotSupported();
 
-			} ).catch( showARNotAllowed );
+            } ).catch( showARNotAllowed );
 
-			return button;
+            return button;
 
-		} else {
+        } else {
 
-			const message = document.createElement( 'a' );
+            const message = document.createElement( 'a' );
 
-			if ( window.isSecureContext === false ) {
+            if ( window.isSecureContext === false ) {
 
-				message.href = document.location.href.replace( /^http:/, 'https:' );
-				message.innerHTML = 'WEBXR NEEDS HTTPS'; // TODO Improve message
+                message.href = document.location.href.replace( /^http:/, 'https:' );
+                message.innerHTML = 'WEBXR NEEDS HTTPS'; // TODO Improve message
 
-			} else {
+            } else {
 
-				message.href = 'https://immersiveweb.dev/';
-				message.innerHTML = 'WEBXR NOT AVAILABLE';
+                message.href = 'https://immersiveweb.dev/';
+                message.innerHTML = 'WEBXR NOT AVAILABLE';
 
-			}
+            }
 
-			message.style.left = 'calc(50% - 90px)';
-			message.style.width = '180px';
-			message.style.textDecoration = 'none';
+            message.style.left = 'calc(50% - 90px)';
+            message.style.width = '180px';
+            message.style.textDecoration = 'none';
 
-			stylizeElement( message );
+            stylizeElement( message );
 
-			return message;
+            return message;
 
-		}
+        }
 
-	}
+    }
 
 }

--- a/src/webxr/ARButton.js
+++ b/src/webxr/ARButton.js
@@ -1,0 +1,230 @@
+export class ARButton {
+
+	static createButton( renderer, sessionInit = {} ) {
+
+		const button = document.createElement( 'button' );
+
+		function showStartAR( /*device*/ ) {
+
+			if ( sessionInit.domOverlay === undefined ) {
+
+				const overlay = document.createElement( 'div' );
+				overlay.style.display = 'none';
+				document.body.appendChild( overlay );
+
+				const svg = document.createElementNS( 'http://www.w3.org/2000/svg', 'svg' );
+				svg.setAttribute( 'width', 38 );
+				svg.setAttribute( 'height', 38 );
+				svg.style.position = 'absolute';
+				svg.style.right = '20px';
+				svg.style.top = '20px';
+				svg.addEventListener( 'click', function () {
+
+					currentSession.end();
+
+				} );
+				overlay.appendChild( svg );
+
+				const path = document.createElementNS( 'http://www.w3.org/2000/svg', 'path' );
+				path.setAttribute( 'd', 'M 12,12 L 28,28 M 28,12 12,28' );
+				path.setAttribute( 'stroke', '#fff' );
+				path.setAttribute( 'stroke-width', 2 );
+				svg.appendChild( path );
+
+				if ( sessionInit.optionalFeatures === undefined ) {
+
+					sessionInit.optionalFeatures = [];
+
+				}
+
+				sessionInit.optionalFeatures.push( 'dom-overlay' );
+				sessionInit.domOverlay = { root: overlay };
+
+			}
+
+			//
+
+			let currentSession = null;
+
+			async function onSessionStarted( session ) {
+
+				session.addEventListener( 'end', onSessionEnded );
+
+				renderer.xr.setReferenceSpaceType( 'local' );
+
+				await renderer.xr.setSession( session );
+
+				button.textContent = 'STOP AR';
+				sessionInit.domOverlay.root.style.display = '';
+
+				currentSession = session;
+
+			}
+
+			function onSessionEnded( /*event*/ ) {
+
+				currentSession.removeEventListener( 'end', onSessionEnded );
+
+				button.textContent = 'START AR';
+				sessionInit.domOverlay.root.style.display = 'none';
+
+				currentSession = null;
+
+			}
+
+			//
+
+			button.style.display = '';
+
+			button.style.cursor = 'pointer';
+			button.style.left = 'calc(50% - 50px)';
+			button.style.width = '100px';
+
+			button.textContent = 'START AR';
+
+			button.onmouseenter = function () {
+
+				button.style.opacity = '1.0';
+
+			};
+
+			button.onmouseleave = function () {
+
+				button.style.opacity = '0.5';
+
+			};
+
+			button.onclick = function () {
+
+				if ( currentSession === null ) {
+
+					navigator.xr.requestSession( 'immersive-ar', sessionInit ).then( onSessionStarted );
+
+				} else {
+
+					currentSession.end();
+
+					if ( navigator.xr.offerSession !== undefined ) {
+
+						navigator.xr.offerSession( 'immersive-ar', sessionInit )
+							.then( onSessionStarted )
+							.catch( ( err ) => {
+
+								console.warn( err );
+
+							} );
+
+					}
+
+				}
+
+			};
+
+			if ( navigator.xr.offerSession !== undefined ) {
+
+				navigator.xr.offerSession( 'immersive-ar', sessionInit )
+					.then( onSessionStarted )
+					.catch( ( err ) => {
+
+						console.warn( err );
+
+					} );
+
+			}
+
+		}
+
+		function disableButton() {
+
+			button.style.display = '';
+
+			button.style.cursor = 'auto';
+			button.style.left = 'calc(50% - 75px)';
+			button.style.width = '150px';
+
+			button.onmouseenter = null;
+			button.onmouseleave = null;
+
+			button.onclick = null;
+
+		}
+
+		function showARNotSupported() {
+
+			disableButton();
+
+			button.textContent = 'AR NOT SUPPORTED';
+
+		}
+
+		function showARNotAllowed( exception ) {
+
+			disableButton();
+
+			console.warn( 'Exception when trying to call xr.isSessionSupported', exception );
+
+			button.textContent = 'AR NOT ALLOWED';
+
+		}
+
+		function stylizeElement( element ) {
+
+			element.style.position = 'absolute';
+			element.style.bottom = '20px';
+			element.style.padding = '12px 6px';
+			element.style.border = '1px solid #fff';
+			element.style.borderRadius = '4px';
+			element.style.background = 'rgba(0,0,0,0.1)';
+			element.style.color = '#fff';
+			element.style.font = 'normal 13px sans-serif';
+			element.style.textAlign = 'center';
+			element.style.opacity = '0.5';
+			element.style.outline = 'none';
+			element.style.zIndex = '999';
+
+		}
+
+		if ( 'xr' in navigator ) {
+
+			button.id = 'ARButton';
+			button.style.display = 'none';
+
+			stylizeElement( button );
+
+			navigator.xr.isSessionSupported( 'immersive-ar' ).then( function ( supported ) {
+
+				supported ? showStartAR() : showARNotSupported();
+
+			} ).catch( showARNotAllowed );
+
+			return button;
+
+		} else {
+
+			const message = document.createElement( 'a' );
+
+			if ( window.isSecureContext === false ) {
+
+				message.href = document.location.href.replace( /^http:/, 'https:' );
+				message.innerHTML = 'WEBXR NEEDS HTTPS'; // TODO Improve message
+
+			} else {
+
+				message.href = 'https://immersiveweb.dev/';
+				message.innerHTML = 'WEBXR NOT AVAILABLE';
+
+			}
+
+			message.style.left = 'calc(50% - 90px)';
+			message.style.width = '180px';
+			message.style.textDecoration = 'none';
+
+			stylizeElement( message );
+
+			return message;
+
+		}
+
+	}
+
+}

--- a/src/webxr/ARButton.js
+++ b/src/webxr/ARButton.js
@@ -1,3 +1,17 @@
+/*
+Copyright © 2010-2024 three.js authors & Mark Kellogg
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+*/
+
 export class ARButton {
 
     static createButton( renderer, sessionInit = {} ) {

--- a/src/webxr/VRButton.js
+++ b/src/webxr/VRButton.js
@@ -169,9 +169,13 @@ export class VRButton {
 
 			} ).catch( showVRNotAllowed );
 
+            console.log ("VR Ready!!")
+
 			return button;
 
 		} else {
+
+            console.log ("FAILED!!")
 
 			const message = document.createElement( 'a' );
 

--- a/src/webxr/VRButton.js
+++ b/src/webxr/VRButton.js
@@ -1,225 +1,221 @@
 export class VRButton {
 
-	static createButton( renderer ) {
+    static createButton( renderer ) {
 
-		const button = document.createElement( 'button' );
+        const button = document.createElement( 'button' );
 
-		function showEnterVR( /*device*/ ) {
+        function showEnterVR( /* device */ ) {
 
-			let currentSession = null;
+            let currentSession = null;
 
-			async function onSessionStarted( session ) {
+            async function onSessionStarted( session ) {
 
-				session.addEventListener( 'end', onSessionEnded );
+                session.addEventListener( 'end', onSessionEnded );
 
-				await renderer.xr.setSession( session );
-				button.textContent = 'EXIT VR';
+                await renderer.xr.setSession( session );
+                button.textContent = 'EXIT VR';
 
-				currentSession = session;
+                currentSession = session;
 
-			}
+            }
 
-			function onSessionEnded( /*event*/ ) {
+            function onSessionEnded( /* event */ ) {
 
-				currentSession.removeEventListener( 'end', onSessionEnded );
+                currentSession.removeEventListener( 'end', onSessionEnded );
 
-				button.textContent = 'ENTER VR';
+                button.textContent = 'ENTER VR';
 
-				currentSession = null;
+                currentSession = null;
 
-			}
+            }
 
-			//
+            //
 
-			button.style.display = '';
+            button.style.display = '';
 
-			button.style.cursor = 'pointer';
-			button.style.left = 'calc(50% - 50px)';
-			button.style.width = '100px';
+            button.style.cursor = 'pointer';
+            button.style.left = 'calc(50% - 50px)';
+            button.style.width = '100px';
 
-			button.textContent = 'ENTER VR';
+            button.textContent = 'ENTER VR';
 
-			// WebXR's requestReferenceSpace only works if the corresponding feature
-			// was requested at session creation time. For simplicity, just ask for
-			// the interesting ones as optional features, but be aware that the
-			// requestReferenceSpace call will fail if it turns out to be unavailable.
-			// ('local' is always available for immersive sessions and doesn't need to
-			// be requested separately.)
+            // WebXR's requestReferenceSpace only works if the corresponding feature
+            // was requested at session creation time. For simplicity, just ask for
+            // the interesting ones as optional features, but be aware that the
+            // requestReferenceSpace call will fail if it turns out to be unavailable.
+            // ('local' is always available for immersive sessions and doesn't need to
+            // be requested separately.)
 
-			const sessionInit = { optionalFeatures: [ 'local-floor', 'bounded-floor', 'hand-tracking', 'layers' ] };
+            const sessionInit = { optionalFeatures: ['local-floor', 'bounded-floor', 'hand-tracking', 'layers'] };
 
-			button.onmouseenter = function () {
+            button.onmouseenter = function() {
 
-				button.style.opacity = '1.0';
+                button.style.opacity = '1.0';
 
-			};
+            };
 
-			button.onmouseleave = function () {
+            button.onmouseleave = function() {
 
-				button.style.opacity = '0.5';
+                button.style.opacity = '0.5';
 
-			};
+            };
 
-			button.onclick = function () {
+            button.onclick = function() {
 
-				if ( currentSession === null ) {
+                if ( currentSession === null ) {
 
-					navigator.xr.requestSession( 'immersive-vr', sessionInit ).then( onSessionStarted );
+                    navigator.xr.requestSession( 'immersive-vr', sessionInit ).then( onSessionStarted );
 
-				} else {
+                } else {
 
-					currentSession.end();
+                    currentSession.end();
 
-					if ( navigator.xr.offerSession !== undefined ) {
+                    if ( navigator.xr.offerSession !== undefined ) {
 
-						navigator.xr.offerSession( 'immersive-vr', sessionInit )
-							.then( onSessionStarted )
-							.catch( ( err ) => {
+                        navigator.xr.offerSession( 'immersive-vr', sessionInit )
+                            .then( onSessionStarted )
+                            .catch( ( err ) => {
 
-								console.warn( err );
+                                console.warn( err );
 
-							} );
+                            } );
 
-					}
+                    }
 
-				}
+                }
 
-			};
+            };
 
-			if ( navigator.xr.offerSession !== undefined ) {
+            if ( navigator.xr.offerSession !== undefined ) {
 
-				navigator.xr.offerSession( 'immersive-vr', sessionInit )
-					.then( onSessionStarted )
-					.catch( ( err ) => {
+                navigator.xr.offerSession( 'immersive-vr', sessionInit )
+                    .then( onSessionStarted )
+                    .catch( ( err ) => {
 
-						console.warn( err );
+                        console.warn( err );
 
-					} );
+                    } );
 
-			}
+            }
 
-		}
+        }
 
-		function disableButton() {
+        function disableButton() {
 
-			button.style.display = '';
+            button.style.display = '';
 
-			button.style.cursor = 'auto';
-			button.style.left = 'calc(50% - 75px)';
-			button.style.width = '150px';
+            button.style.cursor = 'auto';
+            button.style.left = 'calc(50% - 75px)';
+            button.style.width = '150px';
 
-			button.onmouseenter = null;
-			button.onmouseleave = null;
+            button.onmouseenter = null;
+            button.onmouseleave = null;
 
-			button.onclick = null;
+            button.onclick = null;
 
-		}
+        }
 
-		function showWebXRNotFound() {
+        function showWebXRNotFound() {
 
-			disableButton();
+            disableButton();
 
-			button.textContent = 'VR NOT SUPPORTED';
+            button.textContent = 'VR NOT SUPPORTED';
 
-		}
+        }
 
-		function showVRNotAllowed( exception ) {
+        function showVRNotAllowed( exception ) {
 
-			disableButton();
+            disableButton();
 
-			console.warn( 'Exception when trying to call xr.isSessionSupported', exception );
+            console.warn( 'Exception when trying to call xr.isSessionSupported', exception );
 
-			button.textContent = 'VR NOT ALLOWED';
+            button.textContent = 'VR NOT ALLOWED';
 
-		}
+        }
 
-		function stylizeElement( element ) {
+        function stylizeElement( element ) {
 
-			element.style.position = 'absolute';
-			element.style.bottom = '20px';
-			element.style.padding = '12px 6px';
-			element.style.border = '1px solid #fff';
-			element.style.borderRadius = '4px';
-			element.style.background = 'rgba(0,0,0,0.1)';
-			element.style.color = '#fff';
-			element.style.font = 'normal 13px sans-serif';
-			element.style.textAlign = 'center';
-			element.style.opacity = '0.5';
-			element.style.outline = 'none';
-			element.style.zIndex = '999';
+            element.style.position = 'absolute';
+            element.style.bottom = '20px';
+            element.style.padding = '12px 6px';
+            element.style.border = '1px solid #fff';
+            element.style.borderRadius = '4px';
+            element.style.background = 'rgba(0,0,0,0.1)';
+            element.style.color = '#fff';
+            element.style.font = 'normal 13px sans-serif';
+            element.style.textAlign = 'center';
+            element.style.opacity = '0.5';
+            element.style.outline = 'none';
+            element.style.zIndex = '999';
 
-		}
+        }
 
-		if ( 'xr' in navigator ) {
+        if ( 'xr' in navigator ) {
 
-			button.id = 'VRButton';
-			button.style.display = 'none';
+            button.id = 'VRButton';
+            button.style.display = 'none';
 
-			stylizeElement( button );
+            stylizeElement( button );
 
-			navigator.xr.isSessionSupported( 'immersive-vr' ).then( function ( supported ) {
+            navigator.xr.isSessionSupported( 'immersive-vr' ).then( function( supported ) {
 
-				supported ? showEnterVR() : showWebXRNotFound();
+                supported ? showEnterVR() : showWebXRNotFound();
 
-				if ( supported && VRButton.xrSessionIsGranted ) {
+                if ( supported && VRButton.xrSessionIsGranted ) {
 
-					button.click();
+                    button.click();
 
-				}
+                }
 
-			} ).catch( showVRNotAllowed );
+            } ).catch( showVRNotAllowed );
 
-            console.log ("VR Ready!!")
+            return button;
 
-			return button;
+        } else {
 
-		} else {
+            const message = document.createElement( 'a' );
 
-            console.log ("FAILED!!")
+            if ( window.isSecureContext === false ) {
 
-			const message = document.createElement( 'a' );
+                message.href = document.location.href.replace( /^http:/, 'https:' );
+                message.innerHTML = 'WEBXR NEEDS HTTPS'; // TODO Improve message
 
-			if ( window.isSecureContext === false ) {
+            } else {
 
-				message.href = document.location.href.replace( /^http:/, 'https:' );
-				message.innerHTML = 'WEBXR NEEDS HTTPS'; // TODO Improve message
+                message.href = 'https://immersiveweb.dev/';
+                message.innerHTML = 'WEBXR NOT AVAILABLE';
 
-			} else {
+            }
 
-				message.href = 'https://immersiveweb.dev/';
-				message.innerHTML = 'WEBXR NOT AVAILABLE';
+            message.style.left = 'calc(50% - 90px)';
+            message.style.width = '180px';
+            message.style.textDecoration = 'none';
 
-			}
+            stylizeElement( message );
 
-			message.style.left = 'calc(50% - 90px)';
-			message.style.width = '180px';
-			message.style.textDecoration = 'none';
+            return message;
 
-			stylizeElement( message );
+        }
 
-			return message;
+    }
 
-		}
+    static registerSessionGrantedListener() {
 
-	}
+        if ( typeof navigator !== 'undefined' && 'xr' in navigator ) {
 
-	static registerSessionGrantedListener() {
+            // WebXRViewer (based on Firefox) has a bug where addEventListener
+            // throws a silent exception and aborts execution entirely.
+            if ( /WebXRViewer\//i.test( navigator.userAgent ) ) return;
 
-		if ( typeof navigator !== 'undefined' && 'xr' in navigator ) {
+            navigator.xr.addEventListener( 'sessiongranted', () => {
 
-			// WebXRViewer (based on Firefox) has a bug where addEventListener
-			// throws a silent exception and aborts execution entirely.
-			if ( /WebXRViewer\//i.test( navigator.userAgent ) ) return;
+                VRButton.xrSessionIsGranted = true;
 
-			navigator.xr.addEventListener( 'sessiongranted', () => {
+            } );
 
-				VRButton.xrSessionIsGranted = true;
+        }
 
-			} );
-
-		}
-
-	}
+    }
 
 }
 

--- a/src/webxr/VRButton.js
+++ b/src/webxr/VRButton.js
@@ -1,3 +1,17 @@
+/*
+Copyright © 2010-2024 three.js authors & Mark Kellogg
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+*/
+
 export class VRButton {
 
     static createButton( renderer ) {

--- a/src/webxr/VRButton.js
+++ b/src/webxr/VRButton.js
@@ -1,0 +1,223 @@
+export class VRButton {
+
+	static createButton( renderer ) {
+
+		const button = document.createElement( 'button' );
+
+		function showEnterVR( /*device*/ ) {
+
+			let currentSession = null;
+
+			async function onSessionStarted( session ) {
+
+				session.addEventListener( 'end', onSessionEnded );
+
+				await renderer.xr.setSession( session );
+				button.textContent = 'EXIT VR';
+
+				currentSession = session;
+
+			}
+
+			function onSessionEnded( /*event*/ ) {
+
+				currentSession.removeEventListener( 'end', onSessionEnded );
+
+				button.textContent = 'ENTER VR';
+
+				currentSession = null;
+
+			}
+
+			//
+
+			button.style.display = '';
+
+			button.style.cursor = 'pointer';
+			button.style.left = 'calc(50% - 50px)';
+			button.style.width = '100px';
+
+			button.textContent = 'ENTER VR';
+
+			// WebXR's requestReferenceSpace only works if the corresponding feature
+			// was requested at session creation time. For simplicity, just ask for
+			// the interesting ones as optional features, but be aware that the
+			// requestReferenceSpace call will fail if it turns out to be unavailable.
+			// ('local' is always available for immersive sessions and doesn't need to
+			// be requested separately.)
+
+			const sessionInit = { optionalFeatures: [ 'local-floor', 'bounded-floor', 'hand-tracking', 'layers' ] };
+
+			button.onmouseenter = function () {
+
+				button.style.opacity = '1.0';
+
+			};
+
+			button.onmouseleave = function () {
+
+				button.style.opacity = '0.5';
+
+			};
+
+			button.onclick = function () {
+
+				if ( currentSession === null ) {
+
+					navigator.xr.requestSession( 'immersive-vr', sessionInit ).then( onSessionStarted );
+
+				} else {
+
+					currentSession.end();
+
+					if ( navigator.xr.offerSession !== undefined ) {
+
+						navigator.xr.offerSession( 'immersive-vr', sessionInit )
+							.then( onSessionStarted )
+							.catch( ( err ) => {
+
+								console.warn( err );
+
+							} );
+
+					}
+
+				}
+
+			};
+
+			if ( navigator.xr.offerSession !== undefined ) {
+
+				navigator.xr.offerSession( 'immersive-vr', sessionInit )
+					.then( onSessionStarted )
+					.catch( ( err ) => {
+
+						console.warn( err );
+
+					} );
+
+			}
+
+		}
+
+		function disableButton() {
+
+			button.style.display = '';
+
+			button.style.cursor = 'auto';
+			button.style.left = 'calc(50% - 75px)';
+			button.style.width = '150px';
+
+			button.onmouseenter = null;
+			button.onmouseleave = null;
+
+			button.onclick = null;
+
+		}
+
+		function showWebXRNotFound() {
+
+			disableButton();
+
+			button.textContent = 'VR NOT SUPPORTED';
+
+		}
+
+		function showVRNotAllowed( exception ) {
+
+			disableButton();
+
+			console.warn( 'Exception when trying to call xr.isSessionSupported', exception );
+
+			button.textContent = 'VR NOT ALLOWED';
+
+		}
+
+		function stylizeElement( element ) {
+
+			element.style.position = 'absolute';
+			element.style.bottom = '20px';
+			element.style.padding = '12px 6px';
+			element.style.border = '1px solid #fff';
+			element.style.borderRadius = '4px';
+			element.style.background = 'rgba(0,0,0,0.1)';
+			element.style.color = '#fff';
+			element.style.font = 'normal 13px sans-serif';
+			element.style.textAlign = 'center';
+			element.style.opacity = '0.5';
+			element.style.outline = 'none';
+			element.style.zIndex = '999';
+
+		}
+
+		if ( 'xr' in navigator ) {
+
+			button.id = 'VRButton';
+			button.style.display = 'none';
+
+			stylizeElement( button );
+
+			navigator.xr.isSessionSupported( 'immersive-vr' ).then( function ( supported ) {
+
+				supported ? showEnterVR() : showWebXRNotFound();
+
+				if ( supported && VRButton.xrSessionIsGranted ) {
+
+					button.click();
+
+				}
+
+			} ).catch( showVRNotAllowed );
+
+			return button;
+
+		} else {
+
+			const message = document.createElement( 'a' );
+
+			if ( window.isSecureContext === false ) {
+
+				message.href = document.location.href.replace( /^http:/, 'https:' );
+				message.innerHTML = 'WEBXR NEEDS HTTPS'; // TODO Improve message
+
+			} else {
+
+				message.href = 'https://immersiveweb.dev/';
+				message.innerHTML = 'WEBXR NOT AVAILABLE';
+
+			}
+
+			message.style.left = 'calc(50% - 90px)';
+			message.style.width = '180px';
+			message.style.textDecoration = 'none';
+
+			stylizeElement( message );
+
+			return message;
+
+		}
+
+	}
+
+	static registerSessionGrantedListener() {
+
+		if ( typeof navigator !== 'undefined' && 'xr' in navigator ) {
+
+			// WebXRViewer (based on Firefox) has a bug where addEventListener
+			// throws a silent exception and aborts execution entirely.
+			if ( /WebXRViewer\//i.test( navigator.userAgent ) ) return;
+
+			navigator.xr.addEventListener( 'sessiongranted', () => {
+
+				VRButton.xrSessionIsGranted = true;
+
+			} );
+
+		}
+
+	}
+
+}
+
+VRButton.xrSessionIsGranted = false;
+VRButton.registerSessionGrantedListener();

--- a/src/webxr/WebXRMode.js
+++ b/src/webxr/WebXRMode.js
@@ -1,0 +1,5 @@
+export const WebXRMode = {
+    None: 0,
+    VR: 1,
+    AR: 2
+};

--- a/util/server.js
+++ b/util/server.js
@@ -4,7 +4,7 @@ import * as path from 'path';
 
 let baseDirectory = '.';
 let port = 8080;
-let host = '127.0.0.1';
+let host = '0.0.0.0';
 let lasttRequesTime = performance.now() / 1000;
 for(let i = 0; i < process.argv.length; ++i) {
   if (process.argv[i] == '-d' && i < process.argv.length - 1) {


### PR DESCRIPTION
- Built-in support for AR and VR modes via WebXR, enabled via a `Viewer` constructor parameter: `webXRMode`. Thanks to @dlazares and @chrisirhc for doing the ground work.
- Added AR/VR demo in `demo/vr.html`
- Cleaned up and added documentation to the rendering code in order to better explain Gaussian-related computations.
- Cleaned up dependency issues in `package.json`. Thanks to @sxxov for pointing those out.
- Fix bug with specifying format when loading scene where `SceneFormat.Splat` was ignored. Thanks to @kgenots for finding the issue.
- Upgrade to Three.js v160