### PR TITLE
Fix addSplatScenes function to correctly use sceneOptions format

### DIFF
--- a/src/Viewer.js
+++ b/src/Viewer.js
@@ -542,7 +542,7 @@ export class Viewer {
         const abortHandlers = [];
         for (let i = 0; i < sceneOptions.length; i++) {
             const loadPromise = this.loadFileToSplatBuffer(sceneOptions[i].path, sceneOptions[i].splatAlphaRemovalThreshold,
-                                                           downloadProgress.bind(this, i), sceneOptions.format);
+                                                           downloadProgress.bind(this, i), sceneOptions[i].format);
             abortHandlers.push(loadPromise.abortHandler);
             loadPromises.push(loadPromise.promise);
         }


### PR DESCRIPTION
addSplatScenes function is not using correctly the format property by scene.

Loading splat scenes like this was not working as the format key was not correctly taken into account in the addSplatScenes function.

`viewer.addSplatScenes([{
        'path': '<path to first .ply, .ksplat, or .splat file>',
        'splatAlphaRemovalThreshold': 20,
        'format': GaussianSplats3D.SceneFormat['KSplat']
    },
    {
        'path': '<path to second .ply, .ksplat, or .splat file>',
        'rotation': [-0.14724434, -0.0761755, 0.1410657, 0.976020],
        'scale': [1.5, 1.5, 1.5],
        'position': [-3, -2, -3.2],
        'format': GaussianSplats3D.SceneFormat['Splat']
    }
])`