### PR TITLE
Add control  over when rendering occurs

### DIFF
--- a/src/RenderMode.js
+++ b/src/RenderMode.js
@@ -1,0 +1,5 @@
+export const RenderMode = {
+    Always: 0,
+    OnChange: 1,
+    Never: 2
+};

--- a/src/SceneHelper.js
+++ b/src/SceneHelper.js
@@ -129,6 +129,10 @@ export class SceneHelper {
         this.meshCursor.visible = visible;
     }
 
+    getMeschCursorVisibility() {
+        return this.meshCursor.visible;
+    }
+
     setMeshCursorPosition(position) {
         this.meshCursor.position.copy(position);
     }

--- a/src/SplatMesh.js
+++ b/src/SplatMesh.js
@@ -72,6 +72,7 @@ export class SplatMesh extends THREE.Mesh {
         this.maxRadius = 0;
         this.visibleRegionRadius = 0;
         this.visibleRegionFadeStartRadius = 0;
+        this.visibleRegionChanging = false;
 
         this.disposed = false;
     }
@@ -921,6 +922,7 @@ export class SplatMesh extends THREE.Mesh {
         this.material.uniforms.currentTime.value = performance.now();
         this.material.uniforms.fadeInComplete.value = fadeInComplete;
         this.material.uniformsNeedUpdate = true;
+        this.visibleRegionChanging = !fadeInComplete;
     }
 
     /**

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ import { OrbitControls } from './OrbitControls.js';
 import { AbortablePromise } from './AbortablePromise.js';
 import { SceneFormat } from './loaders/SceneFormat.js';
 import { WebXRMode } from './webxr/WebXRMode.js';
+import { RenderMode } from './RenderMode.js';
 
 export {
     PlyParser,
@@ -29,5 +30,6 @@ export {
     OrbitControls,
     AbortablePromise,
     SceneFormat,
-    WebXRMode
+    WebXRMode,
+    RenderMode
 };


### PR DESCRIPTION
The `Viewer` class now accepts a new parameter `renderMode`, which lets you control when the viewer renders. It is of the type `RenderMode`:

```
const RenderMode = {
    Always: 0,
    OnChange: 1,
    Never: 2
};
```
- `Always` is the default and will cause the viewer to render every frame.
- `OnChange` will make the viewer only render when a visual element in the scene changes
- `Never` prevents the viewer from doing any rendering