### PR TITLE
Add `maximumDistanceToRender` to the Viewer options

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,8 @@ const viewer = new GaussianSplats3D.Viewer({
     'integerBasedSort': true,
     'dynamicScene': false,
     'webXRMode': GaussianSplats3D.WebXRMode.None,
-    'renderMode': GaussianSplats3D.RenderMode.OnChange
+    'renderMode': GaussianSplats3D.RenderMode.OnChange,
+    'maximumDistanceToRender': 125,
 });
 viewer.addSplatScene('<path to .ply, .ksplat, or .splat file>')
 .then(() => {
@@ -291,6 +292,7 @@ Advanced `Viewer` parameters
 | `dynamicScene` | Tells the viewer to not make any optimizations that depend on the scene being static. Additionally all splat data retrieved from the viewer's splat mesh will not have their respective scene transform applied to them by default.
 | `webXRMode` | Tells the viewer whether or not to enable built-in Web VR or Web AR. Valid values are defined in the `WebXRMode` enum: `None`, `VR`, and `AR`. Defaults to `None`.
 | `renderMode` | Controls when the viewer renders the scene. Valid values are defined in the `RenderMode` enum: `Always`, `OnChange`, and `Never`. Defaults to `Always`.
+| `maximumDistanceToRender` | Maximum splat rendering distance w.r.t. the camera.
 <br>
 
 ### Creating KSPLAT files

--- a/src/Viewer.js
+++ b/src/Viewer.js
@@ -118,6 +118,9 @@ export class Viewer {
 
         this.webXRMode = options.webXRMode || WebXRMode.None;
 
+        // Maximum splat rendering distance w.r.t. the camera.
+        this.maximumDistanceToRender = options.maximumDistanceToRender || 125;
+
         if (this.webXRMode !== WebXRMode.None) {
             this.gpuAcceleratedSort = false;
         }
@@ -1403,7 +1406,7 @@ export class Viewer {
             }
 
             this.sortRunning = true;
-            const { splatRenderCount, shouldSortAll } = this.gatherSceneNodesForSort();
+            const { splatRenderCount, shouldSortAll } = this.gatherSceneNodesForSort(this.maximumDistanceToRender);
             this.splatRenderCount = splatRenderCount;
             this.sortPromise = new Promise((resolve) => {
                 this.sortPromiseResolver = resolve;
@@ -1472,7 +1475,7 @@ export class Viewer {
     /**
      * Determine which splats to render by checking which are inside or close to the view frustum
      */
-    gatherSceneNodesForSort = function() {
+    gatherSceneNodesForSort = function(maximumDistanceToRender) {
 
         const nodeRenderList = [];
         let allSplatsSortBuffer = null;
@@ -1489,8 +1492,6 @@ export class Viewer {
         const nodeSize = (node) => {
             return tempMax.copy(node.max).sub(node.min).length();
         };
-
-        const MaximumDistanceToRender = 125;
 
         return function(gatherAllNodes = false) {
 
@@ -1536,7 +1537,7 @@ export class Viewer {
                         const outOfFovY = cameraAngleYZDot < (cosFovYOver2 - .6);
                         const outOfFovX = cameraAngleXZDot < (cosFovXOver2 - .6);
                         if (!gatherAllNodes && ((outOfFovX || outOfFovY ||
-                             distanceToNode > MaximumDistanceToRender) && distanceToNode > ns)) {
+                             distanceToNode > maximumDistanceToRender) && distanceToNode > ns)) {
                             continue;
                         }
                         splatRenderCount += node.data.indexes.length;


### PR DESCRIPTION
Hi!

This PR allows to modify the `maximumDistanceToRender` parameter as a `Viewer` option (currently hardcoded to `125`). For some large scenes, the default value can be a bit low.