### PR TITLE
Support PLY generated without SH coefficients and just RGB colors

### DIFF
--- a/src/loaders/PlyParser.js
+++ b/src/loaders/PlyParser.js
@@ -134,7 +134,7 @@ export class PlyParser {
         let rawVertex = {};
 
         const propertiesToRead = ['scale_0', 'scale_1', 'scale_2', 'rot_0', 'rot_1', 'rot_2', 'rot_3',
-                                  'x', 'y', 'z', 'f_dc_0', 'f_dc_1', 'f_dc_2', 'opacity'];
+                                  'x', 'y', 'z', 'f_dc_0', 'f_dc_1', 'f_dc_2', 'opacity', 'red', 'green', 'blue'];
 
         const splatArray = new UncompressedSplatArray();
 
@@ -156,6 +156,10 @@ export class PlyParser {
                 newSplat[UncompressedSplatArray.OFFSET.FDC0] = (0.5 + SH_C0 * rawVertex['f_dc_0']) * 255;
                 newSplat[UncompressedSplatArray.OFFSET.FDC1] = (0.5 + SH_C0 * rawVertex['f_dc_1']) * 255;
                 newSplat[UncompressedSplatArray.OFFSET.FDC2] = (0.5 + SH_C0 * rawVertex['f_dc_2']) * 255;
+            } else if (rawVertex['red'] !== undefined) {
+                newSplat[UncompressedSplatArray.OFFSET.FDC0] = rawVertex['red'] * 255;
+                newSplat[UncompressedSplatArray.OFFSET.FDC1] = rawVertex['green'] * 255;
+                newSplat[UncompressedSplatArray.OFFSET.FDC2] = rawVertex['blue'] * 255;
             } else {
                 newSplat[UncompressedSplatArray.OFFSET.FDC0] = 0;
                 newSplat[UncompressedSplatArray.OFFSET.FDC1] = 0;


### PR DESCRIPTION
Hi!

Some GS builders (like Nerfstudio) can generate GS files without SH coefficients, and in that case the splat colors may be simply defined as `red`, `green` and `blue` (`uchar`). This PR adds support for such files.