### PR TITLE
v0.3.5: Various small bug fixes and updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@mkkellogg/gaussian-splats-3d",
-    "version": "0.3.4",
+    "version": "0.3.5",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@mkkellogg/gaussian-splats-3d",
-            "version": "0.3.4",
+            "version": "0.3.5",
             "license": "MIT",
             "devDependencies": {
                 "@babel/core": "7.22.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
         "type": "git",
         "url": "https://github.com/mkkellogg/GaussianSplats3D"
     },
-    "version": "0.3.4",
+    "version": "0.3.5",
     "description": "Three.js-based 3D Gaussian splat viewer",
     "module": "build/gaussian-splats-3d.module.js",
     "main": "build/gaussian-splats-3d.umd.cjs",

--- a/src/SceneRevealMode.js
+++ b/src/SceneRevealMode.js
@@ -1,0 +1,5 @@
+export const SceneRevealMode = {
+    Default: 0,
+    Gradual: 1,
+    Instant: 2
+};

--- a/src/SplatMesh.js
+++ b/src/SplatMesh.js
@@ -591,7 +591,6 @@ export class SplatMesh extends THREE.Mesh {
             this.visibleRegionRadius = 0;
             this.visibleRegionFadeStartRadius = 0;
             this.firstRenderTime = -1;
-            this.finalBuild = false;
             this.lastBuildScenes = [];
             this.lastBuildSplatCount = 0;
             this.lastBuildMaxSplatCount = 0;

--- a/src/Viewer.js
+++ b/src/Viewer.js
@@ -128,9 +128,9 @@ export class Viewer {
         this.renderMode = options.renderMode || RenderMode.Always;
 
         // SceneRevealMode.Default results in a nice, slow fade-in effect for progressively loaded scenes,
-        // and fast fade-in for fully loaded, non-streamed scenes.
-        // SceneRevealMode.Gradual will force the slow fade-in even for fully loaded, non streamed scenes.
-        // SceneRevealMode.Instant will force all loaded scene data to be immediately visible;
+        // and a fast fade-in for non progressively loaded scenes.
+        // SceneRevealMode.Gradual will force a slow fade-in for all scenes.
+        // SceneRevealMode.Instant will force all loaded scene data to be immediately visible.
         this.sceneRevealMode = options.sceneRevealMode || SceneRevealMode.Default;
 
         this.controls = null;

--- a/src/Viewer.js
+++ b/src/Viewer.js
@@ -1497,8 +1497,6 @@ export class Viewer {
             return tempMax.copy(node.max).sub(node.min).length();
         };
 
-        const MaximumDistanceToRender = 125;
-
         return function(gatherAllNodes = false) {
 
             this.getRenderDimensions(renderDimensions);
@@ -1542,8 +1540,7 @@ export class Viewer {
                         const ns = nodeSize(node);
                         const outOfFovY = cameraAngleYZDot < (cosFovYOver2 - .6);
                         const outOfFovX = cameraAngleXZDot < (cosFovXOver2 - .6);
-                        if (!gatherAllNodes && ((outOfFovX || outOfFovY ||
-                             distanceToNode > MaximumDistanceToRender) && distanceToNode > ns)) {
+                        if (!gatherAllNodes && ((outOfFovX || outOfFovY) && distanceToNode > ns)) {
                             continue;
                         }
                         splatRenderCount += node.data.indexes.length;

--- a/src/Viewer.js
+++ b/src/Viewer.js
@@ -21,6 +21,7 @@ import { ARButton } from './webxr/ARButton.js';
 import { delayedExecute } from './Util.js';
 import { LoaderStatus } from './loaders/LoaderStatus.js';
 import { RenderMode } from './RenderMode.js';
+import { SceneRevealMode } from './SceneRevealMode.js';
 
 const THREE_CAMERA_FOV = 50;
 const MINIMUM_DISTANCE_TO_NEW_FOCAL_POINT = .75;
@@ -122,7 +123,15 @@ export class Viewer {
             this.gpuAcceleratedSort = false;
         }
 
+        // if 'renderMode' is RenderMode.Always, then the viewer will rrender the scene on every update. If it is RenderMode.OnChange,
+        // it will only render when something in the scene has changed.
         this.renderMode = options.renderMode || RenderMode.Always;
+
+        // SceneRevealMode.Default results in a nice, slow fade-in effect for progressively loaded scenes,
+        // and fast fade-in for fully loaded, non-streamed scenes.
+        // SceneRevealMode.Gradual will force the slow fade-in even for fully loaded, non streamed scenes.
+        // SceneRevealMode.Instant will force all loaded scene data to be immediately visible;
+        this.sceneRevealMode = options.sceneRevealMode || SceneRevealMode.Default;
 
         this.controls = null;
 
@@ -1170,7 +1179,7 @@ export class Viewer {
         if (this.dropInMode) this.updateForDropInMode(renderer, camera);
         if (!this.initialized || !this.splatRenderingInitialized) return;
         if (this.controls) this.controls.update();
-        this.splatMesh.updateVisibleRegionFadeDistance();
+        this.splatMesh.updateVisibleRegionFadeDistance(this.sceneRevealMode);
         this.updateSplatSort();
         this.updateForRendererSizeChanges();
         this.updateSplatMesh();

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,7 @@ import { AbortablePromise } from './AbortablePromise.js';
 import { SceneFormat } from './loaders/SceneFormat.js';
 import { WebXRMode } from './webxr/WebXRMode.js';
 import { RenderMode } from './RenderMode.js';
+import { SceneRevealMode } from './SceneRevealMode.js';
 
 export {
     PlyParser,
@@ -33,5 +34,6 @@ export {
     AbortablePromise,
     SceneFormat,
     WebXRMode,
-    RenderMode
+    RenderMode,
+    SceneRevealMode
 };

--- a/src/splattree/SplatTree.js
+++ b/src/splattree/SplatTree.js
@@ -81,6 +81,8 @@ class SplatSubTree {
 let splatTreeWorker;
 function createSplatTreeWorker(self) {
 
+    let WorkerSplatTreeNodeIDGen = 0;
+
     class WorkerBox3 {
 
         constructor(min, max) {
@@ -112,7 +114,7 @@ function createSplatTreeWorker(self) {
     }
 
     class WorkerSplatTreeNode {
-        static idGen = 0;
+
         constructor(min, max, depth, id) {
             this.min = [min[0], min[1], min[2]];
             this.max = [max[0], max[1], max[2]];
@@ -122,7 +124,7 @@ function createSplatTreeWorker(self) {
             this.depth = depth;
             this.children = [];
             this.data = null;
-            this.id = id || WorkerSplatTreeNode.idGen++;
+            this.id = id || WorkerSplatTreeNodeIDGen++;
         }
 
     }


### PR DESCRIPTION
Bug fixes:
- Scenes not fully revealed in standard loading (non-progressive) mode
- Vite integration errors due to `esbuild` not properly handling static class members in web workers

Updates:
- Removed hard-coded maximum render distance
- Added documentation to README about CORS with Vite
- Added `Viewer` constructor parameter for choosing scene reveal mode: `sceneRevealMode`
