### PR TITLE
Support "antialiased" mode + general render quality tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,9 @@ const viewer = new GaussianSplats3D.Viewer({
     'dynamicScene': false,
     'webXRMode': GaussianSplats3D.WebXRMode.None,
     'renderMode': GaussianSplats3D.RenderMode.OnChange,
-    'sceneRevealMode': GaussianSplats3D.SceneRevealMode.Instant
+    'sceneRevealMode': GaussianSplats3D.SceneRevealMode.Instant,
+    `antialiased`: false,
+    `focalAdjustment`: 1.0
 });
 viewer.addSplatScene('<path to .ply, .ksplat, or .splat file>')
 .then(() => {
@@ -286,13 +288,15 @@ Advanced `Viewer` parameters
 | `camera` | Pass an instance of a Three.js `Camera` to the viewer, otherwise it will create its own. Defaults to `undefined`.
 | `ignoreDevicePixelRatio` | Tells the viewer to pretend the device pixel ratio is 1, which can boost performance on devices where it is larger, at a small cost to visual quality. Defaults to `false`.
 | `gpuAcceleratedSort` | Tells the viewer to use a partially GPU-accelerated approach to sorting splats. Currently this means pre-computation of splat distances from the camera is performed on the GPU. It is recommended that this only be set to `true` when `sharedMemoryForWorkers` is also `true`. Defaults to `false` on mobile devices, `true` otherwise.
-| `halfPrecisionCovariancesOnGPU` | Tells the viewer to use 16-bit floating point values when storing splat covariance data in textures, instead of 32-bit. Defaults to `true`.
+| `halfPrecisionCovariancesOnGPU` | Tells the viewer to use 16-bit floating point values when storing splat covariance data in textures, instead of 32-bit. Defaults to `false`.
 | `sharedMemoryForWorkers` | Tells the viewer to use shared memory via a `SharedArrayBuffer` to transfer data to and from the sorting web worker. If set to `false`, it is recommended that `gpuAcceleratedSort` be set to `false` as well. Defaults to `true`.
 | `integerBasedSort` | Tells the sorting web worker to use the integer versions of relevant data to compute the distance of splats from the camera. Since integer arithmetic is faster than floating point, this reduces sort time. However it can result in integer overflows in larger scenes so it should only be used for small scenes. Defaults to `true`.
 | `dynamicScene` | Tells the viewer to not make any optimizations that depend on the scene being static. Additionally all splat data retrieved from the viewer's splat mesh will not have their respective scene transform applied to them by default.
 | `webXRMode` | Tells the viewer whether or not to enable built-in Web VR or Web AR. Valid values are defined in the `WebXRMode` enum: `None`, `VR`, and `AR`. Defaults to `None`.
 | `renderMode` | Controls when the viewer renders the scene. Valid values are defined in the `RenderMode` enum: `Always`, `OnChange`, and `Never`. Defaults to `Always`.
 | `sceneRevealMode` | Controls the fade-in effect used when the scene is loaded. Valid values are defined in the `SceneRevealMode` enum: `Default`, `Gradual`, and `Instant`. `Default` results in a nice, slow fade-in effect for progressively loaded scenes, and a fast fade-in for non progressively loaded scenes. `Gradual` will force a slow fade-in for all scenes. `Instant` will force all loaded scene data to be immediately visible.
+| `antialiased` |  When true, will perform additional steps during rendering to address artifacts caused by the rendering of gaussians at substantially different resolutions than that at which they were rendered during training. This will only work correctly for models that were trained using a process that utilizes this compensation calculation. For more details: https://github.com/nerfstudio-project/gsplat/pull/117, https://github.com/graphdeco-inria/gaussian-splatting/issues/294#issuecomment-1772688093
+| `focalAdjustment` | Hacky, non-scientific parameter for tweaking focal length related calculations. For scenes with very small gaussians & small details, increasing this value can help improve visual quality. Default value is 1.0.
 <br>
 
 ### Creating KSPLAT files

--- a/demo/index.html
+++ b/demo/index.html
@@ -261,6 +261,7 @@
     let currentCameraUpArray;
     let currentCameraPositionArray;
     let currentCameraLookAtArray;
+    let currentAntialiased;
   </script>
   <script type="module">
     import * as GaussianSplats3D from 'gaussian-splats-3d';
@@ -425,6 +426,7 @@
       let cameraUpArray = document.getElementById("cameraUp").value;
       let cameraPositionArray = document.getElementById("cameraPosition").value;
       let cameraLookAtArray = document.getElementById("cameraLookAt").value;
+      let antialiased = document.getElementById("antialiased").checked;
 
       cameraUpArray = cameraUpArray.split(',');
       cameraPositionArray = cameraPositionArray.split(',');
@@ -481,11 +483,13 @@
       currentCameraUpArray = cameraUpArray;
       currentCameraPositionArray = cameraPositionArray;
       currentCameraLookAtArray = cameraLookAtArray;
+      currentAntialiased = antialiased;
+
       try {
         const fileReader = new FileReader();
         fileReader.onload = function(){
           try {
-           runViewer(fileReader.result, format, alphaRemovalThreshold, cameraUpArray, cameraPositionArray, cameraLookAtArray);
+           runViewer(fileReader.result, format, alphaRemovalThreshold, cameraUpArray, cameraPositionArray, cameraLookAtArray, antialiased);
           } catch (e) {
             console.error(e);
             setViewError("Could not view scene.");
@@ -517,18 +521,19 @@
   
     window.addEventListener("popstate", (event) => {
       if (currentAlphaRemovalThreshold !== undefined) {
-        window.location = 'index.html?art=' + currentAlphaRemovalThreshold + '&cu=' + currentCameraUpArray + "&cp=" + currentCameraPositionArray + "&cla=" + currentCameraLookAtArray;
+        window.location = 'index.html?art=' + currentAlphaRemovalThreshold + '&cu=' + currentCameraUpArray + "&cp=" + currentCameraPositionArray + "&cla=" + currentCameraLookAtArray + "&aa=" + currentAntialiased;
       } else {
         window.location = 'index.html';
       }
     });
 
-    function runViewer(splatBufferData, format, alphaRemovalThreshold, cameraUpArray, cameraPositionArray, cameraLookAtArray) {
+    function runViewer(splatBufferData, format, alphaRemovalThreshold, cameraUpArray, cameraPositionArray, cameraLookAtArray, antialiased) {
       const viewerOptions = {
         'cameraUp': cameraUpArray,
         'initialCameraPosition': cameraPositionArray,
         'initialCameraLookAt': cameraLookAtArray,
-        'halfPrecisionCovariancesOnGPU': true,
+        'halfPrecisionCovariancesOnGPU': false,
+        'antialiased': antialiased || false
       };
       const splatBufferOptions = {
         'splatAlphaRemovalThreshold': alphaRemovalThreshold
@@ -636,6 +641,14 @@
                         <input id="alphaRemovalThresholdView" type="text" class="text-input" style="width: 50px" value="1"></input>
                         <span class="valid-value-label">(1 - 255)</span>
                     </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        Anti-aliased
+                      </td>
+                      <td style="text-align:lefts;">
+                        <input type="checkbox" id="antialiased" class="checkbox-input"/>
+                      </td>
                     </tr>
                     <tr>
                     <td>
@@ -845,6 +858,9 @@
         } else if (varName == "cla") {
           currentCameraLookAtArray = component[1];
           document.getElementById('cameraLookAt').value = currentCameraLookAtArray;
+        } else if (varName == "aa") {
+          currentAntialiased = component[1];
+          document.getElementById('antialiased').checked = currentAntialiased;
         }
       }
     }

--- a/src/SplatMesh.js
+++ b/src/SplatMesh.js
@@ -947,7 +947,7 @@ export class SplatMesh extends THREE.Mesh {
             this.maxRadius = maxRadius;
             this.visibleRegionRadius = Math.max(this.maxRadius - visibleAreaEpansionRadius, 0.0);
         }
-        if (this.finalBuild) this.visibleRegionRadius = this.maxRadius;
+        if (this.finalBuild) this.visibleRegionRadius = this.maxRadius = maxDistFromSceneCenter;
         this.updateVisibleRegionFadeDistance();
     }
 

--- a/src/SplatMesh.js
+++ b/src/SplatMesh.js
@@ -26,7 +26,7 @@ export class SplatMesh extends THREE.Mesh {
 
     constructor(dynamicMode = true, halfPrecisionCovariancesOnGPU = false, devicePixelRatio = 1,
                 enableDistancesComputationOnGPU = true, integerBasedDistancesComputation = false,
-                antialiased = false, maxClipSpaceSplatSize = 2048) {
+                antialiased = false, maxScreenSpaceSplatSize = 2048) {
         super(dummyGeometry, dummyMaterial);
         // Reference to a Three.js renderer
         this.renderer = undefined;
@@ -50,7 +50,7 @@ export class SplatMesh extends THREE.Mesh {
         // https://github.com/graphdeco-inria/gaussian-splatting/issues/294#issuecomment-1772688093
         this.antialiased = antialiased;
         // Specify the maximum clip space splat size, can help deal with large splats that get too unwieldy
-        this.maxClipSpaceSplatSize = maxClipSpaceSplatSize;
+        this.maxScreenSpaceSplatSize = maxScreenSpaceSplatSize;
         // The individual splat scenes stored in this splat mesh, each containing their own transform
         this.scenes = [];
         // Special octree tailored to SplatMesh instances
@@ -98,10 +98,10 @@ export class SplatMesh extends THREE.Mesh {
      *                             that the splat count might change
      * @param {boolean} antialiased If true, calculate compensation factor to deal with gaussians being rendered at a significantly
      *                              different resolution than that of their training
-     * @param {number} maxClipSpaceSplatSize The maximum clip space splat size
+     * @param {number} maxScreenSpaceSplatSize The maximum clip space splat size
      * @return {THREE.ShaderMaterial}
      */
-    static buildMaterial(dynamicMode = false, antialiased = false, maxClipSpaceSplatSize = 2048) {
+    static buildMaterial(dynamicMode = false, antialiased = false, maxScreenSpaceSplatSize = 2048) {
 
         // Contains the code to project 3D covariance to 2D and from there calculate the quad (using the eigen vectors of the
         // 2D covariance) that is ultimately rasterized
@@ -285,8 +285,8 @@ export class SplatMesh extends THREE.Mesh {
                 vec2 eigenVector2 = vec2(eigenVector1.y, -eigenVector1.x);
 
                 // We use sqrt(8) standard deviations instead of 3 to eliminate more of the splat with a very low opacity.
-                vec2 basisVector1 = eigenVector1 * min(sqrt8 * sqrt(eigenValue1), ${parseInt(maxClipSpaceSplatSize)}.0);
-                vec2 basisVector2 = eigenVector2 * min(sqrt8 * sqrt(eigenValue2), ${parseInt(maxClipSpaceSplatSize)}.0);
+                vec2 basisVector1 = eigenVector1 * min(sqrt8 * sqrt(eigenValue1), ${parseInt(maxScreenSpaceSplatSize)}.0);
+                vec2 basisVector2 = eigenVector2 * min(sqrt8 * sqrt(eigenValue2), ${parseInt(maxScreenSpaceSplatSize)}.0);
 
                 if (fadeInComplete == 0) {
                     float opacityAdjust = 1.0;
@@ -639,7 +639,7 @@ export class SplatMesh extends THREE.Mesh {
             this.lastBuildMaxSplatCount = 0;
             this.disposeMeshData();
             this.geometry = SplatMesh.buildGeomtery(maxSplatCount);
-            this.material = SplatMesh.buildMaterial(this.dynamicMode, this.antialiased, this.maxClipSpaceSplatSize);
+            this.material = SplatMesh.buildMaterial(this.dynamicMode, this.antialiased, this.maxScreenSpaceSplatSize);
             const indexMaps = SplatMesh.buildSplatIndexMaps(splatBuffers);
             this.globalSplatIndexToLocalSplatIndexMap = indexMaps.localSplatIndexMap;
             this.globalSplatIndexToSceneIndexMap = indexMaps.sceneIndexMap;

--- a/src/SplatMesh.js
+++ b/src/SplatMesh.js
@@ -1329,7 +1329,8 @@ export class SplatMesh extends THREE.Mesh {
         gl.bindVertexArray(this.distancesTransformFeedback.vao);
 
         const ArrayType = this.integerBasedDistancesComputation ? Uint32Array : Float32Array;
-        const subBufferOffset = isUpdateBuild ? this.lastBuildSplatCount * 16 : 0;
+        const attributeBytesPerCenter = this.integerBasedDistancesComputation ? 16 : 12;
+        const subBufferOffset = isUpdateBuild ? this.lastBuildSplatCount * attributeBytesPerCenter : 0;
         const srcCenters = this.integerBasedDistancesComputation ?
                            this.getIntegerCenters(true, isUpdateBuild) :
                            this.getFloatCenters(false, isUpdateBuild);
@@ -1618,7 +1619,7 @@ export class SplatMesh extends THREE.Mesh {
             for (let t = 0; t < 3; t++) {
                 paddedFloatCenters[i * 4 + t] = floatCenters[i * 3 + t];
             }
-            paddedFloatCenters[i * 4 + 3] = 1;
+            paddedFloatCenters[i * 4 + 3] = 1.0;
         }
         return paddedFloatCenters;
     }

--- a/src/Viewer.js
+++ b/src/Viewer.js
@@ -118,10 +118,6 @@ export class Viewer {
         // https://github.com/graphdeco-inria/gaussian-splatting/issues/294#issuecomment-1772688093
         const antialiased = options.antialiased || false;
 
-        this.splatMesh = new SplatMesh(dynamicScene, this.halfPrecisionCovariancesOnGPU, this.devicePixelRatio,
-                                       this.gpuAcceleratedSort, this.integerBasedSort, antialiased);
-
-
         this.webXRMode = options.webXRMode || WebXRMode.None;
 
         if (this.webXRMode !== WebXRMode.None) {
@@ -138,9 +134,15 @@ export class Viewer {
         // SceneRevealMode.Instant will force all loaded scene data to be immediately visible.
         this.sceneRevealMode = options.sceneRevealMode || SceneRevealMode.Default;
 
-        // Hacky, non-scientific parameter for tweaking focal length related calculations. For scenes with very small gaussians & small
-        // details, increasing this value can help improve visual quality.
+        // Hacky, experimental, non-scientific parameter for tweaking focal length related calculations. For scenes with very
+        // small gaussians, small details, and small dimensions -- increasing this value can help improve visual quality.
         this.focalAdjustment = options.focalAdjustment || 1.0;
+
+        // Specify the maximum clip space splat size, can help deal with large splats that get too unwieldy
+        this.maxClipSpaceSplatSize = options.maxClipSpaceSplatSize || 2048;
+
+        this.splatMesh = new SplatMesh(dynamicScene, this.halfPrecisionCovariancesOnGPU, this.devicePixelRatio,
+                                       this.gpuAcceleratedSort, this.integerBasedSort, antialiased, this.maxClipSpaceSplatSize);
 
         this.controls = null;
 

--- a/src/Viewer.js
+++ b/src/Viewer.js
@@ -1429,7 +1429,7 @@ export class Viewer {
             positionDiff = sortViewOffset.copy(this.camera.position).sub(lastSortViewPos).length();
 
             if (!this.forceSort && !this.splatMesh.dynamicMode && queuedSorts.length === 0) {
-                if (angleDiff <= 0.95) needsRefreshForRotation = true;
+                if (angleDiff <= 0.99) needsRefreshForRotation = true;
                 if (positionDiff >= 1.0) needsRefreshForPosition = true;
                 if (!needsRefreshForRotation && !needsRefreshForPosition) return;
             }

--- a/src/Viewer.js
+++ b/src/Viewer.js
@@ -138,11 +138,11 @@ export class Viewer {
         // small gaussians, small details, and small dimensions -- increasing this value can help improve visual quality.
         this.focalAdjustment = options.focalAdjustment || 1.0;
 
-        // Specify the maximum clip space splat size, can help deal with large splats that get too unwieldy
-        this.maxClipSpaceSplatSize = options.maxClipSpaceSplatSize || 2048;
+        // Specify the maximum screen-space splat size, can help deal with large splats that get too unwieldy
+        this.maxScreenSpaceSplatSize = options.maxScreenSpaceSplatSize || 2048;
 
         this.splatMesh = new SplatMesh(dynamicScene, this.halfPrecisionCovariancesOnGPU, this.devicePixelRatio,
-                                       this.gpuAcceleratedSort, this.integerBasedSort, antialiased, this.maxClipSpaceSplatSize);
+                                       this.gpuAcceleratedSort, this.integerBasedSort, antialiased, this.maxScreenSpaceSplatSize);
 
         this.controls = null;
 

--- a/src/ui/InfoPanel.js
+++ b/src/ui/InfoPanel.js
@@ -12,9 +12,10 @@ export class InfoPanel {
             ['Camera up', 'cameraUp'],
             ['Cursor position', 'cursorPosition'],
             ['FPS', 'fps'],
-            ['Render window', 'renderWindow'],
             ['Rendering:', 'renderSplatCount'],
-            ['Sort time', 'sortTime']
+            ['Sort time', 'sortTime'],
+            ['Render window', 'renderWindow'],
+            ['Focal adjustment', 'focalAdjustment']
         ];
 
         this.infoPanelContainer = document.createElement('div');
@@ -98,7 +99,7 @@ export class InfoPanel {
     }
 
     update = function(renderDimensions, cameraPosition, cameraLookAtPosition, cameraUp,
-                      meshCursorPosition, currentFPS, splatCount, splatRenderCount, splatRenderCountPct, lastSortTime) {
+                      meshCursorPosition, currentFPS, splatCount, splatRenderCount, splatRenderCountPct, lastSortTime, focalAdjustment) {
 
         const cameraPosString = `${cameraPosition.x.toFixed(5)}, ${cameraPosition.y.toFixed(5)}, ${cameraPosition.z.toFixed(5)}`;
         if (this.infoCells.cameraPosition.innerHTML !== cameraPosString) {
@@ -134,6 +135,7 @@ export class InfoPanel {
 
         this.infoCells.sortTime.innerHTML = `${lastSortTime.toFixed(3)} ms`;
 
+        this.infoCells.focalAdjustment.innerHTML = `${focalAdjustment.toFixed(3)}`;
     };
 
     setContainer(container) {


### PR DESCRIPTION
- Support anti-aliased rendering mode, as described in this Nerfstudio thread: https://github.com/nerfstudio-project/gsplat/pull/117. This will only work for models that have been trained with this mode enabled. Activated via `Viewer` parameter `'antialiased': true`.
- `halfPrecisionCovariancesOnGPU` is now `false` by default. It was causing issues for very small models.
- Fixed bug with floating-point splat distance computation on GPU.
- Fixed bug with scene reveal not completing for very small models.