### PR TITLE
Enable orthographic projection when using built-in camera

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,19 @@ Keyboard
   - Ratio of rendered splats to total splats
   - Last splat sort duration
 
-- `P` Toggles a debug object that shows the orientation of the camera controls. It includes a green arrow representing the camera's orbital axis and a white square representing the plane at which the camera's elevation angle is 0.
+- `U` Toggles a debug object that shows the orientation of the camera controls. It includes a green arrow representing the camera's orbital axis and a white square representing the plane at which the camera's elevation angle is 0.
 
 - `Left arrow` Rotate the camera's up vector counter-clockwise
 
 - `Right arrow` Rotate the camera's up vector clockwise
+
+- `P` Toggle point-cloud mode, where each splat is rendered as a filled circle
+
+- `=` Increase splat scale
+
+- `-` Decrease splat scale
+
+- `O` Toggle orthographic mode
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -262,8 +262,8 @@ const viewer = new GaussianSplats3D.Viewer({
     'webXRMode': GaussianSplats3D.WebXRMode.None,
     'renderMode': GaussianSplats3D.RenderMode.OnChange,
     'sceneRevealMode': GaussianSplats3D.SceneRevealMode.Instant,
-    `antialiased`: false,
-    `focalAdjustment`: 1.0
+    'antialiased': false,
+    'focalAdjustment': 1.0
 });
 viewer.addSplatScene('<path to .ply, .ksplat, or .splat file>')
 .then(() => {

--- a/src/OrbitControls.js
+++ b/src/OrbitControls.js
@@ -437,6 +437,11 @@ class OrbitControls extends EventDispatcher {
 
         };
 
+        this.clearDampedRotation = function() {
+            sphericalDelta.theta = 0.0;
+            sphericalDelta.phi = 0.0;
+        };
+
         //
         // internals
         //

--- a/src/SceneHelper.js
+++ b/src/SceneHelper.js
@@ -165,13 +165,17 @@ export class SceneHelper {
 
         const tempPosition = new THREE.Vector3();
         const tempMatrix = new THREE.Matrix4();
+        const toCamera = new THREE.Vector3();
 
         return function(position, camera, viewport) {
             tempMatrix.copy(camera.matrixWorld).invert();
             tempPosition.copy(position).applyMatrix4(tempMatrix);
             tempPosition.normalize().multiplyScalar(10);
             tempPosition.applyMatrix4(camera.matrixWorld);
-            this.focusMarker.position.copy(tempPosition);
+            toCamera.copy(camera.position).sub(position);
+            const toCameraDistance = toCamera.length();
+            this.focusMarker.position.copy(position);
+            this.focusMarker.scale.set(toCameraDistance, toCameraDistance, toCameraDistance);
             this.focusMarker.material.uniforms.realFocusPosition.value.copy(position);
             this.focusMarker.material.uniforms.viewport.value.copy(viewport);
             this.focusMarker.material.uniformsNeedUpdate = true;

--- a/src/SplatMesh.js
+++ b/src/SplatMesh.js
@@ -91,7 +91,7 @@ export class SplatMesh extends THREE.Mesh {
         this.visibleRegionChanging = false;
 
         this.splatScale = 1.0;
-        this.pointCloudMode = false;
+        this.pointCloudModeEnabled = false;
 
         this.disposed = false;
     }
@@ -104,11 +104,11 @@ export class SplatMesh extends THREE.Mesh {
      *                              different resolution than that of their training
      * @param {number} maxScreenSpaceSplatSize The maximum clip space splat size
      * @param {number} splatScale Value by which all splats are scaled in screen-space (default is 1.0)
-     * @param {number} pointCloudMode Render all splats as screen-space circles
+     * @param {number} pointCloudModeEnabled Render all splats as screen-space circles
      * @return {THREE.ShaderMaterial}
      */
     static buildMaterial(dynamicMode = false, antialiased = false,
-                         maxScreenSpaceSplatSize = 2048, splatScale = 1.0, pointCloudMode = false) {
+                         maxScreenSpaceSplatSize = 2048, splatScale = 1.0, pointCloudModeEnabled = false) {
 
         // Contains the code to project 3D covariance to 2D and from there calculate the quad (using the eigen vectors of the
         // 2D covariance) that is ultimately rasterized
@@ -133,7 +133,7 @@ export class SplatMesh extends THREE.Mesh {
             uniform vec2 focal;
             uniform float orthoZoom;
             uniform int orthographicMode;
-            uniform int pointCloudMode;
+            uniform int pointCloudModeEnabled;
             uniform float inverseFocalAdjustment;
             uniform vec2 viewport;
             uniform vec2 basisViewport;
@@ -296,7 +296,7 @@ export class SplatMesh extends THREE.Mesh {
                 float eigenValue1 = traceOver2 + term2;
                 float eigenValue2 = traceOver2 - term2;
 
-                if (pointCloudMode == 1) {
+                if (pointCloudModeEnabled == 1) {
                     eigenValue1 = eigenValue2 = 0.2;
                 }
 
@@ -436,9 +436,9 @@ export class SplatMesh extends THREE.Mesh {
                 'type': 'f',
                 'value': splatScale
             },
-            'pointCloudMode': {
+            'pointCloudModeEnabled': {
                 'type': 'i',
-                'value': pointCloudMode ? 1 : 0
+                'value': pointCloudModeEnabled ? 1 : 0
             }
         };
 
@@ -681,7 +681,7 @@ export class SplatMesh extends THREE.Mesh {
             this.disposeMeshData();
             this.geometry = SplatMesh.buildGeomtery(maxSplatCount);
             this.material = SplatMesh.buildMaterial(this.dynamicMode, this.antialiased,
-                                                    this.maxScreenSpaceSplatSize, this.splatScale, this.pointCloudMode);
+                                                    this.maxScreenSpaceSplatSize, this.splatScale, this.pointCloudModeEnabled);
             const indexMaps = SplatMesh.buildSplatIndexMaps(splatBuffers);
             this.globalSplatIndexToLocalSplatIndexMap = indexMaps.localSplatIndexMap;
             this.globalSplatIndexToSceneIndexMap = indexMaps.sceneIndexMap;
@@ -1079,14 +1079,14 @@ export class SplatMesh extends THREE.Mesh {
         return this.splatScale;
     }
 
-    setPointCloudMode(pointCloudMode) {
-        this.pointCloudMode = pointCloudMode;
-        this.material.uniforms.pointCloudMode.value = pointCloudMode ? 1 : 0;
+    setPointCloudModeEnabled(enabled) {
+        this.pointCloudModeEnabled = enabled;
+        this.material.uniforms.pointCloudModeEnabled.value = enabled ? 1 : 0;
         this.material.uniformsNeedUpdate = true;
     }
 
-    getPointCloudMode() {
-        return this.pointCloudMode;
+    getPointCloudModeEnabled() {
+        return this.pointCloudModeEnabled;
     }
 
     getSplatDataTextures() {

--- a/src/SplatMesh.js
+++ b/src/SplatMesh.js
@@ -138,6 +138,7 @@ export class SplatMesh extends THREE.Mesh {
             uniform float currentTime;
             uniform int fadeInComplete;
             uniform vec3 sceneCenter;
+            uniform float splatScale;
 
             varying vec4 vColor;
             varying vec2 vUv;
@@ -295,8 +296,8 @@ export class SplatMesh extends THREE.Mesh {
                 vec2 eigenVector2 = vec2(eigenVector1.y, -eigenVector1.x);
 
                 // We use sqrt(8) standard deviations instead of 3 to eliminate more of the splat with a very low opacity.
-                vec2 basisVector1 = eigenVector1 * min(sqrt8 * sqrt(eigenValue1), ${parseInt(maxScreenSpaceSplatSize)}.0);
-                vec2 basisVector2 = eigenVector2 * min(sqrt8 * sqrt(eigenValue2), ${parseInt(maxScreenSpaceSplatSize)}.0);
+                vec2 basisVector1 = eigenVector1 * splatScale * min(sqrt8 * sqrt(eigenValue1), ${parseInt(maxScreenSpaceSplatSize)}.0);
+                vec2 basisVector2 = eigenVector2 * splatScale * min(sqrt8 * sqrt(eigenValue2), ${parseInt(maxScreenSpaceSplatSize)}.0);
 
                 if (fadeInComplete == 0) {
                     float opacityAdjust = 1.0;
@@ -419,6 +420,10 @@ export class SplatMesh extends THREE.Mesh {
             'centersColorsTextureSize': {
                 'type': 'v2',
                 'value': new THREE.Vector2(1024, 1024)
+            },
+            'splatScale': {
+                'type': 'f',
+                'value': 1.0
             }
         };
 
@@ -1047,6 +1052,11 @@ export class SplatMesh extends THREE.Mesh {
         };
 
     }();
+
+    setSplatScale(scale = 1) {
+        this.material.uniforms.splatScale.value = scale;
+        this.material.uniformsNeedUpdate = true;
+    }
 
     getSplatDataTextures() {
         return this.splatDataTextures;

--- a/src/Viewer.js
+++ b/src/Viewer.js
@@ -145,6 +145,11 @@ export class Viewer {
                                        this.gpuAcceleratedSort, this.integerBasedSort, antialiased, this.maxScreenSpaceSplatSize);
 
         this.controls = null;
+        this.perspectiveControls = null;
+        this.orthographicControls = null;
+
+        this.orthographicCamera = null;
+        this.perspectiveCamera = null;
 
         this.showMeshCursor = false;
         this.showControlPlane = false;
@@ -275,16 +280,26 @@ export class Viewer {
         this.sceneHelper.setupControlPlane();
 
         if (this.useBuiltInControls && this.webXRMode === WebXRMode.None) {
-            this.perspectiveControls = new OrbitControls(this.perspectiveCamera, this.renderer.domElement);
-            this.orthographicControls = new OrbitControls(this.orthographicCamera, this.renderer.domElement);
+            if (!this.usingExternalCamera) {
+                this.perspectiveControls = new OrbitControls(this.perspectiveCamera, this.renderer.domElement);
+                this.orthographicControls = new OrbitControls(this.orthographicCamera, this.renderer.domElement);
+            } else {
+                if (this.camera.isOrthographicCamera) {
+                    this.orthographicControls = new OrbitControls(this.camera, this.renderer.domElement);
+                } else {
+                    this.perspectiveControls = new OrbitControls(this.camera, this.renderer.domElement);
+                }
+            }
             for (let controls of [this.perspectiveControls, this.orthographicControls]) {
-                controls.listenToKeyEvents(window);
-                controls.rotateSpeed = 0.5;
-                controls.maxPolarAngle = Math.PI * .75;
-                controls.minPolarAngle = 0.1;
-                controls.enableDamping = true;
-                controls.dampingFactor = 0.05;
-                controls.target.copy(this.initialCameraLookAt);
+                if (controls) {
+                    controls.listenToKeyEvents(window);
+                    controls.rotateSpeed = 0.5;
+                    controls.maxPolarAngle = Math.PI * .75;
+                    controls.minPolarAngle = 0.1;
+                    controls.enableDamping = true;
+                    controls.dampingFactor = 0.05;
+                    controls.target.copy(this.initialCameraLookAt);
+                }
             }
             this.controls = this.camera.isOrthographicCamera ? this.orthographicControls : this.perspectiveControls;
             this.mouseMoveListener = this.onMouseMove.bind(this);

--- a/src/Viewer.js
+++ b/src/Viewer.js
@@ -1269,10 +1269,14 @@ export class Viewer {
                 }
                 return false;
             };
+
             const savedAuoClear = this.renderer.autoClear;
-            this.renderer.autoClear = false;
-            if (hasRenderables(this.threeScene)) this.renderer.render(this.threeScene, this.camera);
+            if (hasRenderables(this.threeScene)) {
+                this.renderer.render(this.threeScene, this.camera);
+                this.renderer.autoClear = false;
+            }
             this.renderer.render(this.splatMesh, this.camera);
+            this.renderer.autoClear = false;
             if (this.sceneHelper.getFocusMarkerOpacity() > 0.0) this.renderer.render(this.sceneHelper.focusMarker, this.camera);
             if (this.showControlPlane) this.renderer.render(this.sceneHelper.controlPlane, this.camera);
             this.renderer.autoClear = savedAuoClear;

--- a/src/Viewer.js
+++ b/src/Viewer.js
@@ -365,7 +365,7 @@ export class Viewer {
                 case 'KeyC':
                     this.showMeshCursor = !this.showMeshCursor;
                 break;
-                case 'KeyP':
+                case 'KeyU':
                     this.showControlPlane = !this.showControlPlane;
                 break;
                 case 'KeyI':
@@ -379,6 +379,21 @@ export class Viewer {
                 case 'KeyO':
                     if (!this.usingExternalCamera) {
                         this.setOrthographicMode(!this.camera.isOrthographicCamera);
+                    }
+                break;
+                case 'KeyP':
+                    if (!this.usingExternalCamera) {
+                        this.splatMesh.setPointCloudMode(!this.splatMesh.getPointCloudMode());
+                    }
+                break;
+                case 'Equal':
+                    if (!this.usingExternalCamera) {
+                        this.splatMesh.setSplatScale(this.splatMesh.getSplatScale() + 0.05);
+                    }
+                break;
+                case 'Minus':
+                    if (!this.usingExternalCamera) {
+                        this.splatMesh.setSplatScale(Math.max(this.splatMesh.getSplatScale() - 0.05, 0.0));
                     }
                 break;
             }
@@ -1477,7 +1492,8 @@ export class Viewer {
             this.infoPanel.update(renderDimensions, this.camera.position, cameraLookAtPosition,
                                   this.camera.up, this.camera.isOrthographicCamera, meshCursorPosition,
                                   this.currentFPS || 'N/A', splatCount, this.splatRenderCount, splatRenderCountPct,
-                                  this.lastSortTime, this.focalAdjustment);
+                                  this.lastSortTime, this.focalAdjustment, this.splatMesh.getSplatScale(),
+                                  this.splatMesh.getPointCloudMode());
         };
 
     }();

--- a/src/Viewer.js
+++ b/src/Viewer.js
@@ -518,7 +518,8 @@ export class Viewer {
                 const focalLengthY = this.camera.projectionMatrix.elements[5] * 0.5 *
                                      this.devicePixelRatio * renderDimensions.y;
 
-                const focalAdjustment = this.focalAdjustment;
+                const focalMultiplier = this.camera.isOrthographicCamera ? (1.0 / this.devicePixelRatio) : 1.0;
+                const focalAdjustment = this.focalAdjustment * focalMultiplier;
                 const inverseFocalAdjustment = 1.0 / focalAdjustment;
 
                 this.splatMesh.updateUniforms(renderDimensions, focalLengthX * focalAdjustment, focalLengthY * focalAdjustment,

--- a/src/Viewer.js
+++ b/src/Viewer.js
@@ -1440,8 +1440,9 @@ export class Viewer {
             const meshCursorPosition = this.showMeshCursor ? this.sceneHelper.meshCursor.position : null;
             const splatRenderCountPct = this.splatRenderCount / splatCount * 100;
             this.infoPanel.update(renderDimensions, this.camera.position, cameraLookAtPosition,
-                                  this.camera.up, meshCursorPosition, this.currentFPS || 'N/A', splatCount,
-                                  this.splatRenderCount, splatRenderCountPct, this.lastSortTime, this.focalAdjustment);
+                                  this.camera.up, this.camera.isOrthographicCamera, meshCursorPosition,
+                                  this.currentFPS || 'N/A', splatCount, this.splatRenderCount, splatRenderCountPct,
+                                  this.lastSortTime, this.focalAdjustment);
         };
 
     }();

--- a/src/Viewer.js
+++ b/src/Viewer.js
@@ -383,7 +383,7 @@ export class Viewer {
                 break;
                 case 'KeyP':
                     if (!this.usingExternalCamera) {
-                        this.splatMesh.setPointCloudMode(!this.splatMesh.getPointCloudMode());
+                        this.splatMesh.setPointCloudModeEnabled(!this.splatMesh.getPointCloudModeEnabled());
                     }
                 break;
                 case 'Equal':

--- a/src/raycaster/Raycaster.js
+++ b/src/raycaster/Raycaster.js
@@ -21,7 +21,7 @@ export class Raycaster {
                 this.ray.direction.set(ndcCoords.x, ndcCoords.y, 0.5 ).unproject(camera).sub(this.ray.origin).normalize();
                 this.camera = camera;
             } else if (camera.isOrthographicCamera) {
-                this.ray.origin.set(screenPosition.x, screenPosition.y,
+                this.ray.origin.set(ndcCoords.x, ndcCoords.y,
                                    (camera.near + camera.far) / (camera.near - camera.far)).unproject(camera);
                 this.ray.direction.set(0, 0, -1).transformDirection(camera.matrixWorld);
                 this.camera = camera;

--- a/src/ui/InfoPanel.js
+++ b/src/ui/InfoPanel.js
@@ -10,6 +10,7 @@ export class InfoPanel {
             ['Camera position', 'cameraPosition'],
             ['Camera look-at', 'cameraLookAt'],
             ['Camera up', 'cameraUp'],
+            ['Camera mode', 'orthographicCamera'],
             ['Cursor position', 'cursorPosition'],
             ['FPS', 'fps'],
             ['Rendering:', 'renderSplatCount'],
@@ -98,8 +99,9 @@ export class InfoPanel {
         this.visible = false;
     }
 
-    update = function(renderDimensions, cameraPosition, cameraLookAtPosition, cameraUp,
-                      meshCursorPosition, currentFPS, splatCount, splatRenderCount, splatRenderCountPct, lastSortTime, focalAdjustment) {
+    update = function(renderDimensions, cameraPosition, cameraLookAtPosition, cameraUp, orthographicCamera,
+                      meshCursorPosition, currentFPS, splatCount, splatRenderCount,
+                      splatRenderCountPct, lastSortTime, focalAdjustment) {
 
         const cameraPosString = `${cameraPosition.x.toFixed(5)}, ${cameraPosition.y.toFixed(5)}, ${cameraPosition.z.toFixed(5)}`;
         if (this.infoCells.cameraPosition.innerHTML !== cameraPosString) {
@@ -118,6 +120,8 @@ export class InfoPanel {
         if (this.infoCells.cameraUp.innerHTML !== cameraUpString) {
             this.infoCells.cameraUp.innerHTML = cameraUpString;
         }
+
+        this.infoCells.orthographicCamera.innerHTML = orthographicCamera ? 'Orthographic' : 'Perspective';
 
         if (meshCursorPosition) {
             const cursPos = meshCursorPosition;

--- a/src/ui/InfoPanel.js
+++ b/src/ui/InfoPanel.js
@@ -16,7 +16,9 @@ export class InfoPanel {
             ['Rendering:', 'renderSplatCount'],
             ['Sort time', 'sortTime'],
             ['Render window', 'renderWindow'],
-            ['Focal adjustment', 'focalAdjustment']
+            ['Focal adjustment', 'focalAdjustment'],
+            ['Splat scale', 'splatScale'],
+            ['Point cloud mode', 'pointCloudMode']
         ];
 
         this.infoPanelContainer = document.createElement('div');
@@ -101,7 +103,7 @@ export class InfoPanel {
 
     update = function(renderDimensions, cameraPosition, cameraLookAtPosition, cameraUp, orthographicCamera,
                       meshCursorPosition, currentFPS, splatCount, splatRenderCount,
-                      splatRenderCountPct, lastSortTime, focalAdjustment) {
+                      splatRenderCountPct, lastSortTime, focalAdjustment, splatScale, pointCloudMode) {
 
         const cameraPosString = `${cameraPosition.x.toFixed(5)}, ${cameraPosition.y.toFixed(5)}, ${cameraPosition.z.toFixed(5)}`;
         if (this.infoCells.cameraPosition.innerHTML !== cameraPosString) {
@@ -138,8 +140,9 @@ export class InfoPanel {
             `${splatRenderCount} splats out of ${splatCount} (${splatRenderCountPct.toFixed(2)}%)`;
 
         this.infoCells.sortTime.innerHTML = `${lastSortTime.toFixed(3)} ms`;
-
         this.infoCells.focalAdjustment.innerHTML = `${focalAdjustment.toFixed(3)}`;
+        this.infoCells.splatScale.innerHTML = `${splatScale.toFixed(3)}`;
+        this.infoCells.pointCloudMode.innerHTML = `${pointCloudMode}`;
     };
 
     setContainer(container) {


### PR DESCRIPTION
- Support orthographic rendering, enabled via `Viewer.setOrthographicMode()`
- Added `SplatMesh.setSplatScale()` to set the value by which splats are scaled in screen-space (default is 1.0)
- Added `SplatMesh.setPointCloudMode()` to enable/disable point-cloud mode, where each splat is rendered as a filled circle