### PR TITLE
Updated visualization modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,19 @@ Keyboard
   - Ratio of rendered splats to total splats
   - Last splat sort duration
 
-- `P` Toggles a debug object that shows the orientation of the camera controls. It includes a green arrow representing the camera's orbital axis and a white square representing the plane at which the camera's elevation angle is 0.
+- `U` Toggles a debug object that shows the orientation of the camera controls. It includes a green arrow representing the camera's orbital axis and a white square representing the plane at which the camera's elevation angle is 0.
 
 - `Left arrow` Rotate the camera's up vector counter-clockwise
 
 - `Right arrow` Rotate the camera's up vector clockwise
+
+- `P` Toggle point-cloud mode, where each splat is rendered as a filled circle
+
+- `=` Increase splat scale
+
+- `-` Decrease splat scale
+
+- `O` Toggle orthographic mode
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -262,8 +262,8 @@ const viewer = new GaussianSplats3D.Viewer({
     'webXRMode': GaussianSplats3D.WebXRMode.None,
     'renderMode': GaussianSplats3D.RenderMode.OnChange,
     'sceneRevealMode': GaussianSplats3D.SceneRevealMode.Instant,
-    `antialiased`: false,
-    `focalAdjustment`: 1.0
+    'antialiased': false,
+    'focalAdjustment': 1.0
 });
 viewer.addSplatScene('<path to .ply, .ksplat, or .splat file>')
 .then(() => {

--- a/src/OrbitControls.js
+++ b/src/OrbitControls.js
@@ -437,6 +437,11 @@ class OrbitControls extends EventDispatcher {
 
         };
 
+        this.clearDampedRotation = function() {
+            sphericalDelta.theta = 0.0;
+            sphericalDelta.phi = 0.0;
+        };
+
         //
         // internals
         //

--- a/src/SceneHelper.js
+++ b/src/SceneHelper.js
@@ -165,13 +165,17 @@ export class SceneHelper {
 
         const tempPosition = new THREE.Vector3();
         const tempMatrix = new THREE.Matrix4();
+        const toCamera = new THREE.Vector3();
 
         return function(position, camera, viewport) {
             tempMatrix.copy(camera.matrixWorld).invert();
             tempPosition.copy(position).applyMatrix4(tempMatrix);
             tempPosition.normalize().multiplyScalar(10);
             tempPosition.applyMatrix4(camera.matrixWorld);
-            this.focusMarker.position.copy(tempPosition);
+            toCamera.copy(camera.position).sub(position);
+            const toCameraDistance = toCamera.length();
+            this.focusMarker.position.copy(position);
+            this.focusMarker.scale.set(toCameraDistance, toCameraDistance, toCameraDistance);
             this.focusMarker.material.uniforms.realFocusPosition.value.copy(position);
             this.focusMarker.material.uniforms.viewport.value.copy(viewport);
             this.focusMarker.material.uniformsNeedUpdate = true;

--- a/src/SplatMesh.js
+++ b/src/SplatMesh.js
@@ -91,7 +91,7 @@ export class SplatMesh extends THREE.Mesh {
         this.visibleRegionChanging = false;
 
         this.splatScale = 1.0;
-        this.pointCloudMode = false;
+        this.pointCloudModeEnabled = false;
 
         this.disposed = false;
     }
@@ -104,11 +104,11 @@ export class SplatMesh extends THREE.Mesh {
      *                              different resolution than that of their training
      * @param {number} maxScreenSpaceSplatSize The maximum clip space splat size
      * @param {number} splatScale Value by which all splats are scaled in screen-space (default is 1.0)
-     * @param {number} pointCloudMode Render all splats as screen-space circles
+     * @param {number} pointCloudModeEnabled Render all splats as screen-space circles
      * @return {THREE.ShaderMaterial}
      */
     static buildMaterial(dynamicMode = false, antialiased = false,
-                         maxScreenSpaceSplatSize = 2048, splatScale = 1.0, pointCloudMode = false) {
+                         maxScreenSpaceSplatSize = 2048, splatScale = 1.0, pointCloudModeEnabled = false) {
 
         // Contains the code to project 3D covariance to 2D and from there calculate the quad (using the eigen vectors of the
         // 2D covariance) that is ultimately rasterized
@@ -133,7 +133,7 @@ export class SplatMesh extends THREE.Mesh {
             uniform vec2 focal;
             uniform float orthoZoom;
             uniform int orthographicMode;
-            uniform int pointCloudMode;
+            uniform int pointCloudModeEnabled;
             uniform float inverseFocalAdjustment;
             uniform vec2 viewport;
             uniform vec2 basisViewport;
@@ -296,7 +296,7 @@ export class SplatMesh extends THREE.Mesh {
                 float eigenValue1 = traceOver2 + term2;
                 float eigenValue2 = traceOver2 - term2;
 
-                if (pointCloudMode == 1) {
+                if (pointCloudModeEnabled == 1) {
                     eigenValue1 = eigenValue2 = 0.2;
                 }
 
@@ -436,9 +436,9 @@ export class SplatMesh extends THREE.Mesh {
                 'type': 'f',
                 'value': splatScale
             },
-            'pointCloudMode': {
+            'pointCloudModeEnabled': {
                 'type': 'i',
-                'value': pointCloudMode ? 1 : 0
+                'value': pointCloudModeEnabled ? 1 : 0
             }
         };
 
@@ -681,7 +681,7 @@ export class SplatMesh extends THREE.Mesh {
             this.disposeMeshData();
             this.geometry = SplatMesh.buildGeomtery(maxSplatCount);
             this.material = SplatMesh.buildMaterial(this.dynamicMode, this.antialiased,
-                                                    this.maxScreenSpaceSplatSize, this.splatScale, this.pointCloudMode);
+                                                    this.maxScreenSpaceSplatSize, this.splatScale, this.pointCloudModeEnabled);
             const indexMaps = SplatMesh.buildSplatIndexMaps(splatBuffers);
             this.globalSplatIndexToLocalSplatIndexMap = indexMaps.localSplatIndexMap;
             this.globalSplatIndexToSceneIndexMap = indexMaps.sceneIndexMap;
@@ -1079,14 +1079,14 @@ export class SplatMesh extends THREE.Mesh {
         return this.splatScale;
     }
 
-    setPointCloudMode(pointCloudMode) {
-        this.pointCloudMode = pointCloudMode;
-        this.material.uniforms.pointCloudMode.value = pointCloudMode ? 1 : 0;
+    setPointCloudModeEnabled(enabled) {
+        this.pointCloudModeEnabled = enabled;
+        this.material.uniforms.pointCloudModeEnabled.value = enabled ? 1 : 0;
         this.material.uniformsNeedUpdate = true;
     }
 
-    getPointCloudMode() {
-        return this.pointCloudMode;
+    getPointCloudModeEnabled() {
+        return this.pointCloudModeEnabled;
     }
 
     getSplatDataTextures() {

--- a/src/SplatMesh.js
+++ b/src/SplatMesh.js
@@ -138,6 +138,7 @@ export class SplatMesh extends THREE.Mesh {
             uniform float currentTime;
             uniform int fadeInComplete;
             uniform vec3 sceneCenter;
+            uniform float splatScale;
 
             varying vec4 vColor;
             varying vec2 vUv;
@@ -295,8 +296,8 @@ export class SplatMesh extends THREE.Mesh {
                 vec2 eigenVector2 = vec2(eigenVector1.y, -eigenVector1.x);
 
                 // We use sqrt(8) standard deviations instead of 3 to eliminate more of the splat with a very low opacity.
-                vec2 basisVector1 = eigenVector1 * min(sqrt8 * sqrt(eigenValue1), ${parseInt(maxScreenSpaceSplatSize)}.0);
-                vec2 basisVector2 = eigenVector2 * min(sqrt8 * sqrt(eigenValue2), ${parseInt(maxScreenSpaceSplatSize)}.0);
+                vec2 basisVector1 = eigenVector1 * splatScale * min(sqrt8 * sqrt(eigenValue1), ${parseInt(maxScreenSpaceSplatSize)}.0);
+                vec2 basisVector2 = eigenVector2 * splatScale * min(sqrt8 * sqrt(eigenValue2), ${parseInt(maxScreenSpaceSplatSize)}.0);
 
                 if (fadeInComplete == 0) {
                     float opacityAdjust = 1.0;
@@ -419,6 +420,10 @@ export class SplatMesh extends THREE.Mesh {
             'centersColorsTextureSize': {
                 'type': 'v2',
                 'value': new THREE.Vector2(1024, 1024)
+            },
+            'splatScale': {
+                'type': 'f',
+                'value': 1.0
             }
         };
 
@@ -1047,6 +1052,11 @@ export class SplatMesh extends THREE.Mesh {
         };
 
     }();
+
+    setSplatScale(scale = 1) {
+        this.material.uniforms.splatScale.value = scale;
+        this.material.uniformsNeedUpdate = true;
+    }
 
     getSplatDataTextures() {
         return this.splatDataTextures;

--- a/src/SplatMesh.js
+++ b/src/SplatMesh.js
@@ -672,6 +672,7 @@ export class SplatMesh extends THREE.Mesh {
             this.scenes[0].splatBuffer !== this.lastBuildScenes[0].splatBuffer) {
                 isUpdateBuild = false;
        }
+
        if (!isUpdateBuild) {
             isUpdateBuild = false;
             this.boundingBox = new THREE.Box3();

--- a/src/SplatMesh.js
+++ b/src/SplatMesh.js
@@ -651,6 +651,7 @@ export class SplatMesh extends THREE.Mesh {
      *                                            builder worker starts and finishes.
      * @param {function} onSplatTreeConstruction Function to be called when the conversion of the local splat tree from
      *                                           the format produced by the splat tree builder worker starts and ends.
+     * @return {object} Object containing info about the splats that are updated
      */
     build(splatBuffers, sceneOptions, keepSceneTransforms = true, finalBuild = false,
           onSplatTreeIndexesUpload, onSplatTreeConstruction) {
@@ -704,6 +705,19 @@ export class SplatMesh extends THREE.Mesh {
         for (let i = 0; i < this.scenes.length; i++) {
             this.lastBuildScenes[i] = this.scenes[i];
         }
+
+        const updateInfo = {
+            'from': this.lastBuildSplatCount,
+            'to': this.getSplatCount() - 1,
+            'updateCount': this.getSplatCount() - this.lastBuildSplatCount
+        };
+        if (!this.enableDistancesComputationOnGPU) {
+            updateInfo.centers = this.integerBasedDistancesComputation ?
+                                 this.getIntegerCenters(true, isUpdateBuild) :
+                                 this.getFloatCenters(false, isUpdateBuild);
+            updateInfo.transformIndexes = this.getTransformIndexes(isUpdateBuild);
+        }
+
         this.lastBuildSplatCount = this.getSplatCount();
         this.lastBuildMaxSplatCount = this.getMaxSplatCount();
         this.lastBuildSceneCount = this.scenes.length;
@@ -715,6 +729,8 @@ export class SplatMesh extends THREE.Mesh {
                 if (this.onSplatTreeReadyCallback) this.onSplatTreeReadyCallback(this.splatTree);
             });
         }
+
+        return updateInfo;
     }
 
     /**
@@ -823,7 +839,7 @@ export class SplatMesh extends THREE.Mesh {
         this.uploadSplatDataToTextures(isUpdateBuild);
         if (this.enableDistancesComputationOnGPU) {
             this.updateGPUCentersBufferForDistancesComputation(isUpdateBuild);
-            this.updateGPUTransformIndexesBufferForDistancesComputation();
+            this.updateGPUTransformIndexesBufferForDistancesComputation(isUpdateBuild);
         }
     }
 
@@ -1465,7 +1481,7 @@ export class SplatMesh extends THREE.Mesh {
         if (isUpdateBuild) {
             gl.bufferSubData(gl.ARRAY_BUFFER, subBufferOffset, srcCenters);
         } else {
-            const maxArray = new ArrayType(this.getMaxSplatCount() * 16);
+            const maxArray = new ArrayType(this.getMaxSplatCount() * attributeBytesPerCenter);
             maxArray.set(srcCenters);
             gl.bufferData(gl.ARRAY_BUFFER, maxArray, gl.STATIC_DRAW);
         }
@@ -1477,8 +1493,9 @@ export class SplatMesh extends THREE.Mesh {
 
     /**
      * Refresh GPU buffers used for pre-computing splat distances with centers data from the scenes for this mesh.
+     * @param {boolean} isUpdateBuild Specify whether or not to only update for splats that have been added since the last build.
      */
-    updateGPUTransformIndexesBufferForDistancesComputation() {
+    updateGPUTransformIndexesBufferForDistancesComputation(isUpdateBuild) {
 
         if (!this.renderer || !this.dynamicMode) return;
 
@@ -1487,8 +1504,16 @@ export class SplatMesh extends THREE.Mesh {
         const currentVao = gl.getParameter(gl.VERTEX_ARRAY_BINDING);
         gl.bindVertexArray(this.distancesTransformFeedback.vao);
 
+        const subBufferOffset = isUpdateBuild ? this.lastBuildSplatCount * 4 : 0;
+        const transformIndexes = this.getTransformIndexes(isUpdateBuild);
+
         gl.bindBuffer(gl.ARRAY_BUFFER, this.distancesTransformFeedback.transformIndexesBuffer);
-        gl.bufferData(gl.ARRAY_BUFFER, this.getTransformIndexes(), gl.STATIC_DRAW);
+
+        if (isUpdateBuild) {
+            gl.bufferSubData(gl.ARRAY_BUFFER, subBufferOffset, transformIndexes);
+        } else {
+            gl.bufferData(gl.ARRAY_BUFFER, transformIndexes, gl.STATIC_DRAW);
+        }
         gl.bindBuffer(gl.ARRAY_BUFFER, null);
 
         if (currentVao) gl.bindVertexArray(currentVao);
@@ -1496,11 +1521,24 @@ export class SplatMesh extends THREE.Mesh {
 
     /**
      * Get a typed array containing a mapping from global splat indexes to their scene index.
+     * @param {boolean} isUpdateBuild Specify whether or not to only update for splats that have been added since the last build.
      * @return {Uint32Array}
      */
-    getTransformIndexes() {
-        const transformIndexes = new Uint32Array(this.globalSplatIndexToSceneIndexMap.length);
-        transformIndexes.set(this.globalSplatIndexToSceneIndexMap);
+    getTransformIndexes(isUpdateBuild) {
+
+        let transformIndexes;
+        if (isUpdateBuild) {
+            const splatCount = this.getSplatCount();
+            const fillCount = splatCount - this.lastBuildSplatCount;
+            transformIndexes = new Uint32Array(fillCount);
+            for (let i = this.lastBuildSplatCount; i < splatCount; i++) {
+                transformIndexes[i] = this.globalSplatIndexToSceneIndexMap[i];
+            }
+        } else {
+            transformIndexes = new Uint32Array(this.globalSplatIndexToSceneIndexMap.length);
+            transformIndexes.set(this.globalSplatIndexToSceneIndexMap);
+        }
+
         return transformIndexes;
     }
 
@@ -1729,7 +1767,6 @@ export class SplatMesh extends THREE.Mesh {
         }
         return intCenters;
     }
-
 
     /**
      * Returns an array of splat centers, transformed as appropriate, optionally padded.

--- a/src/Util.js
+++ b/src/Util.js
@@ -138,10 +138,10 @@ export const disposeAllMeshes = (object3D) => {
     }
 };
 
-export const delayedExecute = (func) => {
+export const delayedExecute = (func, fast) => {
     return new Promise((resolve) => {
         window.setTimeout(() => {
             resolve(func());
-        }, 50);
+        }, fast ? 1 : 50);
     });
 };

--- a/src/Util.js
+++ b/src/Util.js
@@ -142,6 +142,6 @@ export const delayedExecute = (func) => {
     return new Promise((resolve) => {
         window.setTimeout(() => {
             resolve(func());
-        }, 1);
+        }, 50);
     });
 };

--- a/src/Viewer.js
+++ b/src/Viewer.js
@@ -145,6 +145,11 @@ export class Viewer {
                                        this.gpuAcceleratedSort, this.integerBasedSort, antialiased, this.maxScreenSpaceSplatSize);
 
         this.controls = null;
+        this.perspectiveControls = null;
+        this.orthographicControls = null;
+
+        this.orthographicCamera = null;
+        this.perspectiveCamera = null;
 
         this.showMeshCursor = false;
         this.showControlPlane = false;
@@ -275,16 +280,26 @@ export class Viewer {
         this.sceneHelper.setupControlPlane();
 
         if (this.useBuiltInControls && this.webXRMode === WebXRMode.None) {
-            this.perspectiveControls = new OrbitControls(this.perspectiveCamera, this.renderer.domElement);
-            this.orthographicControls = new OrbitControls(this.orthographicCamera, this.renderer.domElement);
+            if (!this.usingExternalCamera) {
+                this.perspectiveControls = new OrbitControls(this.perspectiveCamera, this.renderer.domElement);
+                this.orthographicControls = new OrbitControls(this.orthographicCamera, this.renderer.domElement);
+            } else {
+                if (this.camera.isOrthographicCamera) {
+                    this.orthographicControls = new OrbitControls(this.camera, this.renderer.domElement);
+                } else {
+                    this.perspectiveControls = new OrbitControls(this.camera, this.renderer.domElement);
+                }
+            }
             for (let controls of [this.perspectiveControls, this.orthographicControls]) {
-                controls.listenToKeyEvents(window);
-                controls.rotateSpeed = 0.5;
-                controls.maxPolarAngle = Math.PI * .75;
-                controls.minPolarAngle = 0.1;
-                controls.enableDamping = true;
-                controls.dampingFactor = 0.05;
-                controls.target.copy(this.initialCameraLookAt);
+                if (controls) {
+                    controls.listenToKeyEvents(window);
+                    controls.rotateSpeed = 0.5;
+                    controls.maxPolarAngle = Math.PI * .75;
+                    controls.minPolarAngle = 0.1;
+                    controls.enableDamping = true;
+                    controls.dampingFactor = 0.05;
+                    controls.target.copy(this.initialCameraLookAt);
+                }
             }
             this.controls = this.camera.isOrthographicCamera ? this.orthographicControls : this.perspectiveControls;
             this.mouseMoveListener = this.onMouseMove.bind(this);

--- a/src/Viewer.js
+++ b/src/Viewer.js
@@ -1269,10 +1269,14 @@ export class Viewer {
                 }
                 return false;
             };
+
             const savedAuoClear = this.renderer.autoClear;
-            this.renderer.autoClear = false;
-            if (hasRenderables(this.threeScene)) this.renderer.render(this.threeScene, this.camera);
+            if (hasRenderables(this.threeScene)) {
+                this.renderer.render(this.threeScene, this.camera);
+                this.renderer.autoClear = false;
+            }
             this.renderer.render(this.splatMesh, this.camera);
+            this.renderer.autoClear = false;
             if (this.sceneHelper.getFocusMarkerOpacity() > 0.0) this.renderer.render(this.sceneHelper.focusMarker, this.camera);
             if (this.showControlPlane) this.renderer.render(this.sceneHelper.controlPlane, this.camera);
             this.renderer.autoClear = savedAuoClear;

--- a/src/Viewer.js
+++ b/src/Viewer.js
@@ -365,7 +365,7 @@ export class Viewer {
                 case 'KeyC':
                     this.showMeshCursor = !this.showMeshCursor;
                 break;
-                case 'KeyP':
+                case 'KeyU':
                     this.showControlPlane = !this.showControlPlane;
                 break;
                 case 'KeyI':
@@ -379,6 +379,21 @@ export class Viewer {
                 case 'KeyO':
                     if (!this.usingExternalCamera) {
                         this.setOrthographicMode(!this.camera.isOrthographicCamera);
+                    }
+                break;
+                case 'KeyP':
+                    if (!this.usingExternalCamera) {
+                        this.splatMesh.setPointCloudMode(!this.splatMesh.getPointCloudMode());
+                    }
+                break;
+                case 'Equal':
+                    if (!this.usingExternalCamera) {
+                        this.splatMesh.setSplatScale(this.splatMesh.getSplatScale() + 0.05);
+                    }
+                break;
+                case 'Minus':
+                    if (!this.usingExternalCamera) {
+                        this.splatMesh.setSplatScale(Math.max(this.splatMesh.getSplatScale() - 0.05, 0.0));
                     }
                 break;
             }
@@ -1477,7 +1492,8 @@ export class Viewer {
             this.infoPanel.update(renderDimensions, this.camera.position, cameraLookAtPosition,
                                   this.camera.up, this.camera.isOrthographicCamera, meshCursorPosition,
                                   this.currentFPS || 'N/A', splatCount, this.splatRenderCount, splatRenderCountPct,
-                                  this.lastSortTime, this.focalAdjustment);
+                                  this.lastSortTime, this.focalAdjustment, this.splatMesh.getSplatScale(),
+                                  this.splatMesh.getPointCloudMode());
         };
 
     }();

--- a/src/Viewer.js
+++ b/src/Viewer.js
@@ -518,7 +518,8 @@ export class Viewer {
                 const focalLengthY = this.camera.projectionMatrix.elements[5] * 0.5 *
                                      this.devicePixelRatio * renderDimensions.y;
 
-                const focalAdjustment = this.focalAdjustment;
+                const focalMultiplier = this.camera.isOrthographicCamera ? (1.0 / this.devicePixelRatio) : 1.0;
+                const focalAdjustment = this.focalAdjustment * focalMultiplier;
                 const inverseFocalAdjustment = 1.0 / focalAdjustment;
 
                 this.splatMesh.updateUniforms(renderDimensions, focalLengthX * focalAdjustment, focalLengthY * focalAdjustment,

--- a/src/Viewer.js
+++ b/src/Viewer.js
@@ -1440,8 +1440,9 @@ export class Viewer {
             const meshCursorPosition = this.showMeshCursor ? this.sceneHelper.meshCursor.position : null;
             const splatRenderCountPct = this.splatRenderCount / splatCount * 100;
             this.infoPanel.update(renderDimensions, this.camera.position, cameraLookAtPosition,
-                                  this.camera.up, meshCursorPosition, this.currentFPS || 'N/A', splatCount,
-                                  this.splatRenderCount, splatRenderCountPct, this.lastSortTime, this.focalAdjustment);
+                                  this.camera.up, this.camera.isOrthographicCamera, meshCursorPosition,
+                                  this.currentFPS || 'N/A', splatCount, this.splatRenderCount, splatRenderCountPct,
+                                  this.lastSortTime, this.focalAdjustment);
         };
 
     }();

--- a/src/Viewer.js
+++ b/src/Viewer.js
@@ -383,7 +383,7 @@ export class Viewer {
                 break;
                 case 'KeyP':
                     if (!this.usingExternalCamera) {
-                        this.splatMesh.setPointCloudMode(!this.splatMesh.getPointCloudMode());
+                        this.splatMesh.setPointCloudModeEnabled(!this.splatMesh.getPointCloudModeEnabled());
                     }
                 break;
                 case 'Equal':

--- a/src/raycaster/Raycaster.js
+++ b/src/raycaster/Raycaster.js
@@ -21,7 +21,7 @@ export class Raycaster {
                 this.ray.direction.set(ndcCoords.x, ndcCoords.y, 0.5 ).unproject(camera).sub(this.ray.origin).normalize();
                 this.camera = camera;
             } else if (camera.isOrthographicCamera) {
-                this.ray.origin.set(screenPosition.x, screenPosition.y,
+                this.ray.origin.set(ndcCoords.x, ndcCoords.y,
                                    (camera.near + camera.far) / (camera.near - camera.far)).unproject(camera);
                 this.ray.direction.set(0, 0, -1).transformDirection(camera.matrixWorld);
                 this.camera = camera;

--- a/src/splattree/SplatTree.js
+++ b/src/splattree/SplatTree.js
@@ -311,6 +311,16 @@ export class SplatTree {
         this.splatMesh = null;
     }
 
+
+    dispose() {
+        this.diposeSplatTreeWorker();
+    }
+
+    diposeSplatTreeWorker() {
+        if (splatTreeWorker) splatTreeWorker.terminate();
+        splatTreeWorker = null;
+    };
+
     /**
      * Construct this instance of SplatTree from an instance of SplatMesh.
      *
@@ -347,14 +357,9 @@ export class SplatTree {
             return sceneCenters;
         };
 
-        const diposeSplatTreeWorker = () => {
-            splatTreeWorker.terminate();
-            splatTreeWorker = null;
-        };
-
         const checkForEarlyExit = (resolve) => {
             if (splatMesh.disposed) {
-                diposeSplatTreeWorker();
+                this.diposeSplatTreeWorker();
                 resolve();
                 return true;
             }
@@ -400,7 +405,7 @@ export class SplatTree {
                                 const convertedSubTree = SplatSubTree.convertWorkerSubTree(workerSubTree, splatMesh);
                                 this.subTrees.push(convertedSubTree);
                             }
-                            diposeSplatTreeWorker();
+                            this.diposeSplatTreeWorker();
 
                             if (onSplatTreeConstruction) onSplatTreeConstruction(true);
 

--- a/src/splattree/SplatTree.js
+++ b/src/splattree/SplatTree.js
@@ -317,9 +317,9 @@ export class SplatTree {
      * @param {SplatMesh} splatMesh The instance of SplatMesh from which to construct this splat tree.
      * @param {function} filterFunc Optional function to filter out unwanted splats.
      * @param {function} onIndexesUpload Function to be called when the upload of splat centers to the splat tree
-     *                            builder worker starts and finishes.
+     *                                   builder worker starts and finishes.
      * @param {function} onSplatTreeConstruction Function to be called when the conversion of the local splat tree from
-     *                                    the format produced by the splat tree builder worker starts and ends.
+     *                                           the format produced by the splat tree builder worker starts and ends.
      * @return {undefined}
      */
     processSplatMesh = function(splatMesh, filterFunc = () => true, onIndexesUpload, onSplatTreeConstruction) {

--- a/src/ui/InfoPanel.js
+++ b/src/ui/InfoPanel.js
@@ -10,6 +10,7 @@ export class InfoPanel {
             ['Camera position', 'cameraPosition'],
             ['Camera look-at', 'cameraLookAt'],
             ['Camera up', 'cameraUp'],
+            ['Camera mode', 'orthographicCamera'],
             ['Cursor position', 'cursorPosition'],
             ['FPS', 'fps'],
             ['Rendering:', 'renderSplatCount'],
@@ -98,8 +99,9 @@ export class InfoPanel {
         this.visible = false;
     }
 
-    update = function(renderDimensions, cameraPosition, cameraLookAtPosition, cameraUp,
-                      meshCursorPosition, currentFPS, splatCount, splatRenderCount, splatRenderCountPct, lastSortTime, focalAdjustment) {
+    update = function(renderDimensions, cameraPosition, cameraLookAtPosition, cameraUp, orthographicCamera,
+                      meshCursorPosition, currentFPS, splatCount, splatRenderCount,
+                      splatRenderCountPct, lastSortTime, focalAdjustment) {
 
         const cameraPosString = `${cameraPosition.x.toFixed(5)}, ${cameraPosition.y.toFixed(5)}, ${cameraPosition.z.toFixed(5)}`;
         if (this.infoCells.cameraPosition.innerHTML !== cameraPosString) {
@@ -118,6 +120,8 @@ export class InfoPanel {
         if (this.infoCells.cameraUp.innerHTML !== cameraUpString) {
             this.infoCells.cameraUp.innerHTML = cameraUpString;
         }
+
+        this.infoCells.orthographicCamera.innerHTML = orthographicCamera ? 'Orthographic' : 'Perspective';
 
         if (meshCursorPosition) {
             const cursPos = meshCursorPosition;

--- a/src/ui/InfoPanel.js
+++ b/src/ui/InfoPanel.js
@@ -16,7 +16,9 @@ export class InfoPanel {
             ['Rendering:', 'renderSplatCount'],
             ['Sort time', 'sortTime'],
             ['Render window', 'renderWindow'],
-            ['Focal adjustment', 'focalAdjustment']
+            ['Focal adjustment', 'focalAdjustment'],
+            ['Splat scale', 'splatScale'],
+            ['Point cloud mode', 'pointCloudMode']
         ];
 
         this.infoPanelContainer = document.createElement('div');
@@ -101,7 +103,7 @@ export class InfoPanel {
 
     update = function(renderDimensions, cameraPosition, cameraLookAtPosition, cameraUp, orthographicCamera,
                       meshCursorPosition, currentFPS, splatCount, splatRenderCount,
-                      splatRenderCountPct, lastSortTime, focalAdjustment) {
+                      splatRenderCountPct, lastSortTime, focalAdjustment, splatScale, pointCloudMode) {
 
         const cameraPosString = `${cameraPosition.x.toFixed(5)}, ${cameraPosition.y.toFixed(5)}, ${cameraPosition.z.toFixed(5)}`;
         if (this.infoCells.cameraPosition.innerHTML !== cameraPosString) {
@@ -138,8 +140,9 @@ export class InfoPanel {
             `${splatRenderCount} splats out of ${splatCount} (${splatRenderCountPct.toFixed(2)}%)`;
 
         this.infoCells.sortTime.innerHTML = `${lastSortTime.toFixed(3)} ms`;
-
         this.infoCells.focalAdjustment.innerHTML = `${focalAdjustment.toFixed(3)}`;
+        this.infoCells.splatScale.innerHTML = `${splatScale.toFixed(3)}`;
+        this.infoCells.pointCloudMode.innerHTML = `${pointCloudMode}`;
     };
 
     setContainer(container) {

--- a/src/worker/SortWorker.js
+++ b/src/worker/SortWorker.js
@@ -88,7 +88,7 @@ function sortWorker(self) {
                 new Uint32Array(wasmMemory, transformIndexesOffset, splatCount).set(new Uint32Array(transformIndexes));
             }
             self.postMessage({
-                'sortSetupComplete': true,
+                'centerDataSet': true,
             });
         } else if (e.data.sort) {
             const renderCount = e.data.sort.splatRenderCount || 0;

--- a/src/worker/SortWorker.js
+++ b/src/worker/SortWorker.js
@@ -80,12 +80,15 @@ function sortWorker(self) {
             centers = e.data.centers;
             transformIndexes = e.data.transformIndexes;
             if (integerBasedSort) {
-                new Int32Array(wasmMemory, centersOffset, splatCount * 4).set(new Int32Array(centers));
+                new Int32Array(wasmMemory, centersOffset + e.data.updateInfo.from * 4 * 4,
+                               e.data.updateInfo.updateCount * 4).set(new Int32Array(centers));
             } else {
-                new Float32Array(wasmMemory, centersOffset, splatCount * 4).set(new Float32Array(centers));
+                new Float32Array(wasmMemory, centersOffset + e.data.updateInfo.from * 4 * 4,
+                                 e.data.updateInfo.updateCount * 4).set(new Float32Array(centers));
             }
             if (dynamicMode) {
-                new Uint32Array(wasmMemory, transformIndexesOffset, splatCount).set(new Uint32Array(transformIndexes));
+                new Uint32Array(wasmMemory, transformIndexesOffset + e.data.updateInfo.from * 4,
+                                e.data.updateInfo.updateCount).set(new Uint32Array(transformIndexes));
             }
             self.postMessage({
                 'centerDataSet': true,

--- a/src/worker/SortWorker.js
+++ b/src/worker/SortWorker.js
@@ -80,15 +80,15 @@ function sortWorker(self) {
             centers = e.data.centers;
             transformIndexes = e.data.transformIndexes;
             if (integerBasedSort) {
-                new Int32Array(wasmMemory, centersOffset + e.data.updateInfo.from * 4 * 4,
-                               e.data.updateInfo.updateCount * 4).set(new Int32Array(centers));
+                new Int32Array(wasmMemory, centersOffset + e.data.range.from * 4 * 4,
+                               e.data.range.count * 4).set(new Int32Array(centers));
             } else {
-                new Float32Array(wasmMemory, centersOffset + e.data.updateInfo.from * 4 * 4,
-                                 e.data.updateInfo.updateCount * 4).set(new Float32Array(centers));
+                new Float32Array(wasmMemory, centersOffset + e.data.range.from * 4 * 4,
+                                 e.data.range.count * 4).set(new Float32Array(centers));
             }
             if (dynamicMode) {
-                new Uint32Array(wasmMemory, transformIndexesOffset + e.data.updateInfo.from * 4,
-                                e.data.updateInfo.updateCount).set(new Uint32Array(transformIndexes));
+                new Uint32Array(wasmMemory, transformIndexesOffset + e.data.range.from * 4,
+                                e.data.range.count).set(new Uint32Array(transformIndexes));
             }
             self.postMessage({
                 'centerDataSet': true,


### PR DESCRIPTION
- Support orthographic rendering, enabled via `Viewer.setOrthographicMode()`
- Added `SplatMesh.setSplatScale()` to set the value by which splats are scaled in screen-space (default is 1.0)
- Added `SplatMesh.setPointCloudMode()` to enable/disable point-cloud mode, where each splat is rendered as a filled circle
- Added function to remove a splat scene: `Viewer.removeSplatScene()`