### PR TITLE
Release v0.4.0: 1st & 2nd degree spherical harmonics

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -31,7 +31,8 @@ module.exports = {
       "padded-blocks": ["off"],
       "indent": ["off"],
       "arrow-parens": ["off"],
-      "no-unused-vars": ["error"]
+      "no-unused-vars": ["error"],
+      "valid-jsdoc" : ["off"]
     },
   };
   

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ When I started, web-based viewers were already available -- A WebGL-based viewer
 - Users can convert `.ply` or `.splat` files to the `.ksplat` file format
 - Allows a Three.js scene or object group to be rendered along with the splats
 - Built-in WebXR support
+- Supports 1st and 2nd degree spherical harmonics for view-dependent effects
 - Focus on optimization:
     - Splats culled prior to sorting & rendering using a custom octree
     - WASM splat sort: Implemented in C++ using WASM SIMD instructions
@@ -32,7 +33,6 @@ When I started, web-based viewers were already available -- A WebGL-based viewer
 ## Future work
 This is still very much a work in progress! There are several things that still need to be done:
   - Improve the method by which splat data is stored in textures
-  - Properly incorporate spherical harmonics data to achieve view dependent lighting effects
   - Continue optimizing CPU-based splat sort - maybe try an incremental sort of some kind?
   - Add editing mode, allowing users to modify scene and export changes
   - Support very large scenes
@@ -272,7 +272,8 @@ const viewer = new GaussianSplats3D.Viewer({
     'sceneRevealMode': GaussianSplats3D.SceneRevealMode.Instant,
     'antialiased': false,
     'focalAdjustment': 1.0,
-    'logLevel': GaussianSplats3D.LogLevel.None
+    'logLevel': GaussianSplats3D.LogLevel.None,
+    'sphericalHarmonicsDegree': 0
 });
 viewer.addSplatScene('<path to .ply, .ksplat, or .splat file>')
 .then(() => {
@@ -307,7 +308,7 @@ Advanced `Viewer` parameters
 | `antialiased` |  When true, will perform additional steps during rendering to address artifacts caused by the rendering of gaussians at substantially different resolutions than that at which they were rendered during training. This will only work correctly for models that were trained using a process that utilizes this compensation calculation. For more details: https://github.com/nerfstudio-project/gsplat/pull/117, https://github.com/graphdeco-inria/gaussian-splatting/issues/294#issuecomment-1772688093
 | `focalAdjustment` | Hacky, non-scientific parameter for tweaking focal length related calculations. For scenes with very small gaussians & small details, increasing this value can help improve visual quality. Default value is 1.0.
 | `logLevel` | Verbosity of the console logging. Defaults to `GaussianSplats3D.LogLevel.None`.
-| `sphericalHarmonicsDegree` | Degree of spherical harmonics to utilize in rendering splats (assuming the data is present in the splat scene). Valid values are 0 - 3. Default value is 0.
+| `sphericalHarmonicsDegree` | Degree of spherical harmonics to utilize in rendering splats (assuming the data is present in the splat scene). Valid values are 0, 1, or 2. Default value is 0.
 <br>
 
 ### Creating KSPLAT files
@@ -318,7 +319,11 @@ import * as GaussianSplats3D from '@mkkellogg/gaussian-splats-3d';
 
 const compressionLevel = 1;
 const splatAlphaRemovalThreshold = 5; // out of 255
-GaussianSplats3D.PlyLoader.loadFromURL('<path to .ply or .splat file>', compressionLevel, splatAlphaRemovalThreshold)
+const sphericalHarmonicsDegree = 1;
+GaussianSplats3D.PlyLoader.loadFromURL('<path to .ply or .splat file>',
+                                        compressionLevel,
+                                        splatAlphaRemovalThreshold,
+                                        sphericalHarmonicsDegree)
 .then((splatBuffer) => {
     GaussianSplats3D.KSplatLoader.downloadFile(splatBuffer, 'converted_file.ksplat');
 });
@@ -331,7 +336,7 @@ The third option is to use the included nodejs script:
 node util/create-ksplat.js [path to .PLY or .SPLAT] [output file] [compression level = 0] [alpha removal threshold = 1]
 ```
 
-Currently supported values for `compressionLevel` are `0` or `1`. `0` means no compression, `1` means compression of scale, rotation, and position values from 32-bit to 16-bit.
+Currently supported values for `compressionLevel` are `0`, `1`, or `2`. `0` means no compression and `1` means compression of scale, rotation, position, and spherical harmonics coefficient values from 32-bit to 16-bit. `2` is similar to `1` except spherical harmonics coefficients are compressed to 8-bit.
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@ Advanced `Viewer` parameters
 | `antialiased` |  When true, will perform additional steps during rendering to address artifacts caused by the rendering of gaussians at substantially different resolutions than that at which they were rendered during training. This will only work correctly for models that were trained using a process that utilizes this compensation calculation. For more details: https://github.com/nerfstudio-project/gsplat/pull/117, https://github.com/graphdeco-inria/gaussian-splatting/issues/294#issuecomment-1772688093
 | `focalAdjustment` | Hacky, non-scientific parameter for tweaking focal length related calculations. For scenes with very small gaussians & small details, increasing this value can help improve visual quality. Default value is 1.0.
 | `logLevel` | Verbosity of the console logging. Defaults to `GaussianSplats3D.LogLevel.None`.
+| `sphericalHarmonicsDegree` | Degree of spherical harmonics to utilize in rendering splats (assuming the data is present in the splat scene). Valid values are 0 - 3. Default value is 0.
 <br>
 
 ### Creating KSPLAT files

--- a/demo/bonsai.html
+++ b/demo/bonsai.html
@@ -31,13 +31,17 @@
   <script type="module">
     import * as GaussianSplats3D from '@mkkellogg/gaussian-splats-3d';
     import * as THREE from 'three';
+
+    const urlParams = new URLSearchParams(window.location.search);
+    const mode = parseInt(urlParams.get('mode')) || 0;
+
     const viewer = new GaussianSplats3D.Viewer({
         'cameraUp': [0.01933, -0.75830, -0.65161],
         'initialCameraPosition': [1.54163, 2.68515, -6.37228],
         'initialCameraLookAt': [0.45622, 1.95338, 1.51278],
+        'sphericalHarmonicsDegree': 2
     });
-    let path = 'assets/data/bonsai/bonsai';
-    path += isMobile() ? '.ksplat' : '_high.ksplat';
+    let path = 'assets/data/bonsai/bonsai' + (mode ? '_high' : '') + '.ksplat';
     viewer.addSplatScene(path, {
       'streamView': true
     })

--- a/demo/garden.html
+++ b/demo/garden.html
@@ -31,14 +31,17 @@
   <script type="module">
     import * as GaussianSplats3D from '@mkkellogg/gaussian-splats-3d';
     import * as THREE from 'three';
+
+    const urlParams = new URLSearchParams(window.location.search);
+    const mode = parseInt(urlParams.get('mode')) || 0;
   
     const viewer = new GaussianSplats3D.Viewer({
       'cameraUp': [0, -1, -0.54],
       'initialCameraPosition': [-3.15634, -0.16946, -0.51552],
-      'initialCameraLookAt': [1.52976, 2.27776, 1.65898]
+      'initialCameraLookAt': [1.52976, 2.27776, 1.65898],
+      'sphericalHarmonicsDegree': 2
     });
-    let path = 'assets/data/garden/garden';
-    path += isMobile() ? '.ksplat' : '_high.ksplat';
+    let path = 'assets/data/garden/garden' + (mode ? '_high' : '') + '.ksplat';
     viewer.addSplatScene(path, {
       'streamView': true
     })

--- a/demo/index.html
+++ b/demo/index.html
@@ -282,7 +282,7 @@
 
     window.onCompressionLevelChange = function(arg) {
       const compressionLevel = parseInt(document.getElementById("compressionLevel").value);
-      if (isNaN(compressionLevel) || compressionLevel < 0 || compressionLevel > 1) {
+      if (isNaN(compressionLevel) || compressionLevel < 0 || compressionLevel > 2) {
         return;
       }
 
@@ -335,7 +335,7 @@
   
       const sceneCenter = new THREE.Vector3().fromArray(sceneCenterArray);
 
-      if (isNaN(compressionLevel) || compressionLevel < 0 || compressionLevel > 1) {
+      if (isNaN(compressionLevel) || compressionLevel < 0 || compressionLevel > 2) {
         setConversionError("Invalid compression level.");
         return;
       } else if (isNaN(alphaRemovalThreshold) || alphaRemovalThreshold <0 || alphaRemovalThreshold > 255) {
@@ -692,7 +692,7 @@
                       </td>
                       <td>
                           <input id="viewSphericalHarmonicsDegree" type="text" class="text-input" style="width: 50px" value="0"></input>
-                          <span class="valid-value-label">(0, 1, 2)</span>
+                          <span class="valid-value-label">(0, 1, or 2)</span>
                       </td>
                       </tr>
                 </table>
@@ -753,7 +753,7 @@
                     </td>
                     <td>
                         <input id="compressionLevel" type="text" class="text-input" style="width: 50px" value="1" onChange="window.onCompressionLevelChange(this);"></input>
-                        <span class="valid-value-label">(0 or 1)</span>
+                        <span class="valid-value-label">(0, 1, or 2)</span>
                     </td>
                     </tr>
                     <tr>
@@ -762,7 +762,7 @@
                     </td>
                     <td>
                         <input id="conversionSphericalHarmonicsDegree" type="text" class="text-input" style="width: 50px" value="0"></input>
-                        <span class="valid-value-label">(0, 1, 2)</span>
+                        <span class="valid-value-label">(0, 1, or 2)</span>
                     </td>
                     </tr>
                     <tr id="advancedCompressionRow1">

--- a/demo/index.html
+++ b/demo/index.html
@@ -60,6 +60,7 @@
       font-size: 12pt;
       font-weight: bold;
       color: #333333;
+      margin-bottom: 5px;
     }
 
     .content-row {
@@ -86,7 +87,7 @@
       margin-right: 8px;
     }
 
-    .demo-scene-panel:hover {
+    .demo-scene-panel.clickable:hover {
       color: #333333;
       border-color: #8a9ba8;
       background-color: #e4edfc;
@@ -99,6 +100,28 @@
       margin-bottom: 10px;
       width: 209px;
       height: 149px;
+    }
+
+    .demo-scene-button-row {
+      display: flex;
+      flex-direction: row;
+      width: 100%;
+      justify-content: center;
+    }
+
+    .demo-scene-button {
+      border-radius: 5px;
+      border: #cccccc 2px solid;
+      background-color: #eeeeee;
+      color: #666666;
+      padding: 3px 7px 3px 7px;
+    }
+
+    .demo-scene-button:hover {
+      color: #333333;
+      border: #aaaaaa 2px solid;
+      background-color: #e7eaf1;
+      cursor: pointer;
     }
 
     .button {
@@ -565,8 +588,17 @@
 
   </script>
   <script>
-    function openDemo(demoName) {
-      window.location = demoName + '.html';
+    function openDemo(page, params) {
+      let url = page + '.html';
+      if (params && params.length > 0) {
+        let index = 0;
+        for (let param of params) {
+          url += (index === 0 ? "?" : "&");
+          url += param[0] + "=" + param[1];
+          index++;
+        }
+      }
+      window.location = url;
     }
     function reset() {
       window.location = 'index.html';
@@ -599,29 +631,55 @@
         </div>
         <div style="text-align:center;">
           <div class="content-row" style="max-width: 800px; margin:auto; display:flex; align-items: center; justify-content: center;">
-            <div class="demo-scene-panel" onclick="openDemo('garden')">
+            <div class="demo-scene-panel">
+                <div class="small-title">Garden</div>
                 <img src="assets/images/garden.png" class="demo-scene-panel-image">
-                <span class="small-title">Garden</span>
+                <div class="demo-scene-button-row">
+                  <div class="demo-scene-button" onclick="openDemo('garden', [['mode', '0']])">Low</div>
+                  <div style="width: 10px;"></div>
+                  <div class="demo-scene-button" onclick="openDemo('garden', [['mode', '1']])">High</div>
+                </div>
             </div>
-            <div class="demo-scene-panel" onclick="openDemo('truck')">
+            <div class="demo-scene-panel">
+                <div class="small-title">Truck</div>
                 <img src="assets/images/truck.png" class="demo-scene-panel-image">
-                <span class="small-title">Truck</span>
+                <div class="demo-scene-button-row">
+                  <div class="demo-scene-button" onclick="openDemo('truck', [['mode', '0']])">Low</div>
+                  <div style="width: 10px;"></div>
+                  <div class="demo-scene-button" onclick="openDemo('truck', [['mode', '1']])">High</div>
+                </div>
             </div>
-            <div class="demo-scene-panel" onclick="openDemo('stump')">
-                <img src="assets/images/stump.png" class="demo-scene-panel-image">
-                <span class="small-title">Stump</span>
+            <div class="demo-scene-panel">
+              <div class="small-title">Stump</div>
+              <img src="assets/images/stump.png" class="demo-scene-panel-image">
+              <div class="demo-scene-button-row">
+                <div class="demo-scene-button" onclick="openDemo('stump', [['mode', '0']])">Low</div>
+                <div style="width: 10px;"></div>
+                <div class="demo-scene-button" onclick="openDemo('stump', [['mode', '1']])">High</div>
+              </div>
             </div>
-            <div class="demo-scene-panel" onclick="openDemo('bonsai')">
+            <div class="demo-scene-panel">
+              <div class="small-title">Bonsai</div>
               <img src="assets/images/bonsai.png" class="demo-scene-panel-image">
-              <span class="small-title">Bonsai</span>
-          </div>
-            <div class="demo-scene-panel" onclick="openDemo('dynamic_scenes')">
+              <div class="demo-scene-button-row">
+                <div class="demo-scene-button" onclick="openDemo('bonsai', [['mode', '0']])">Low</div>
+                <div style="width: 10px;"></div>
+                <div class="demo-scene-button" onclick="openDemo('bonsai', [['mode', '1']])">High</div>
+              </div>
+            </div>
+            <div class="demo-scene-panel">
+              <div class="small-title">Dynamic scenes</div>
               <img src="assets/images/dynamic_scenes.png" class="demo-scene-panel-image">
-              <span class="small-title">Dynamic scenes</span>
+              <div class="demo-scene-button-row">
+                <div class="demo-scene-button" onclick="openDemo('dynamic_scenes', [['mode', '0']])">Open</div>
+              </div>
             </div>
-            <div class="demo-scene-panel" onclick="openDemo('vr')">
+            <div class="demo-scene-panel">
+              <div class="small-title">AR/VR</div>
               <img src="assets/images/bonsai.png" class="demo-scene-panel-image">
-              <span class="small-title">AR/VR</span>
+              <div class="demo-scene-button-row">
+                <div class="demo-scene-button" onclick="openDemo('vr', [['mode', '0']])">Open</div>
+              </div>
             </div>
           </div>
         </div>

--- a/demo/index.html
+++ b/demo/index.html
@@ -341,8 +341,8 @@
       } else if (isNaN(alphaRemovalThreshold) || alphaRemovalThreshold <0 || alphaRemovalThreshold > 255) {
         setConversionError("Invalid alpha remval threshold.");
         return;
-      } else if (isNaN(sphericalHarmonicsDegree) || sphericalHarmonicsDegree < 0 || sphericalHarmonicsDegree > 3) {
-        setConversionError("Invalid SH level.");
+      } else if (isNaN(sphericalHarmonicsDegree) || sphericalHarmonicsDegree < 0 || sphericalHarmonicsDegree > 2) {
+        setConversionError("Invalid SH degree.");
         return;
       } else if (isNaN(blockSize) || blockSize < 0.1) {
         setConversionError("Invalid block size.");
@@ -444,10 +444,10 @@
       } else if (isNaN(alphaRemovalThreshold) || alphaRemovalThreshold < 0 || alphaRemovalThreshold > 255) {
         setViewError("Invalid alpha remval threshold.");
         return;
-      } else if (isNaN(sphericalHarmonicsDegree) || sphericalHarmonicsDegree < 0 || sphericalHarmonicsDegree > 3) {
-        setConversionError("Invalid SH level.");
+      } else if (isNaN(sphericalHarmonicsDegree) || sphericalHarmonicsDegree < 0 || sphericalHarmonicsDegree > 2) {
+        setViewError("Invalid SH degree.");
         return;
-      } 
+      }
 
       if (cameraUpArray.length !== 3) {
         setViewError("Camera up must contain 3 elements.");
@@ -629,7 +629,7 @@
     <br>
     <div class="header-content-container">
         <div class="content-row">
-            <div id ="view-panel" class="splat-panel" style="height:350px;">
+            <div id ="view-panel" class="splat-panel" style="height:370px;">
                 <br>
                 <div class="small-title">View a <span class="file-ext">.ply</span>, <span class="file-ext">.ksplat</span>, or <span class="file-ext-small">.splat</span> file</div>
                 <br>
@@ -692,7 +692,7 @@
                       </td>
                       <td>
                           <input id="viewSphericalHarmonicsDegree" type="text" class="text-input" style="width: 50px" value="0"></input>
-                          <span class="valid-value-label">(0, 1, 2, or 3)</span>
+                          <span class="valid-value-label">(0, 1, 2)</span>
                       </td>
                       </tr>
                 </table>
@@ -762,7 +762,7 @@
                     </td>
                     <td>
                         <input id="conversionSphericalHarmonicsDegree" type="text" class="text-input" style="width: 50px" value="0"></input>
-                        <span class="valid-value-label">(0, 1, 2, or 3)</span>
+                        <span class="valid-value-label">(0, 1, 2)</span>
                     </td>
                     </tr>
                     <tr id="advancedCompressionRow1">

--- a/demo/index.html
+++ b/demo/index.html
@@ -543,7 +543,8 @@
         'initialCameraPosition': cameraPositionArray,
         'initialCameraLookAt': cameraLookAtArray,
         'halfPrecisionCovariancesOnGPU': false,
-        'antialiased': antialiased || false
+        'antialiased': antialiased || false,
+        'sphericalHarmonicsDegree': sphericalHarmonicsDegree
       };
       const splatBufferOptions = {
         'splatAlphaRemovalThreshold': alphaRemovalThreshold

--- a/demo/index.html
+++ b/demo/index.html
@@ -262,14 +262,15 @@
     let currentCameraPositionArray;
     let currentCameraLookAtArray;
     let currentAntialiased;
+    let currentSphericalHarmonicsLevel;
   </script>
   <script type="module">
     import * as GaussianSplats3D from 'gaussian-splats-3d';
     import * as THREE from 'three';
 
-    function fileBufferToSplatBuffer(fileBufferData, format, alphaRemovalThreshold, compressionLevel, sectionSize, sceneCenter, blockSize, bucketSize) {
+    function fileBufferToSplatBuffer(fileBufferData, format, alphaRemovalThreshold, compressionLevel, sectionSize, sceneCenter, blockSize, bucketSize, outSphericalHarmonicsLevel = 0) {
       if (format === GaussianSplats3D.SceneFormat.Ply) {
-        return GaussianSplats3D.PlyLoader.loadFromFileData(fileBufferData.data, alphaRemovalThreshold, compressionLevel, sectionSize, sceneCenter, blockSize, bucketSize);
+        return GaussianSplats3D.PlyLoader.loadFromFileData(fileBufferData.data, alphaRemovalThreshold, compressionLevel, sectionSize, sceneCenter, blockSize, bucketSize, outSphericalHarmonicsLevel);
       } else {
         if (format === GaussianSplats3D.SceneFormat.Splat) {
           return GaussianSplats3D.SplatLoader.loadFromFileData(fileBufferData.data, alphaRemovalThreshold, compressionLevel, sectionSize, sceneCenter, blockSize, bucketSize);
@@ -310,6 +311,7 @@
       const conversionFile = document.getElementById("conversionFile");
       const compressionLevel = parseInt(document.getElementById("compressionLevel").value);
       const alphaRemovalThreshold = parseInt(document.getElementById("alphaRemovalThreshold").value);
+      const sphericalHarmonicsLevel = parseInt(document.getElementById("conversionSphericalHarmonicsLevel").value);
       const sectionSize = 0;
       let sceneCenterArray = document.getElementById("sceneCenter").value;
       const blockSize = parseFloat(document.getElementById("blockSize").value);
@@ -338,6 +340,9 @@
         return;
       } else if (isNaN(alphaRemovalThreshold) || alphaRemovalThreshold <0 || alphaRemovalThreshold > 255) {
         setConversionError("Invalid alpha remval threshold.");
+        return;
+      } else if (isNaN(sphericalHarmonicsLevel) || sphericalHarmonicsLevel < 0 || sphericalHarmonicsLevel > 3) {
+        setConversionError("Invalid SH level.");
         return;
       } else if (isNaN(blockSize) || blockSize < 0.1) {
         setConversionError("Invalid block size.");
@@ -379,7 +384,7 @@
           window.setTimeout(() => {
             try {
               const splatBufferPromise = fileBufferToSplatBuffer(fileData, format, alphaRemovalThreshold, compressionLevel,
-                                                                 sectionSize, sceneCenter, blockSize, bucketSize);
+                                                                 sectionSize, sceneCenter, blockSize, bucketSize, sphericalHarmonicsLevel);
               splatBufferPromise.then((splatBuffer) => {
                 GaussianSplats3D.KSplatLoader.downloadFile(splatBuffer, 'converted_file.ksplat');
                 conversionDone();
@@ -427,6 +432,7 @@
       let cameraPositionArray = document.getElementById("cameraPosition").value;
       let cameraLookAtArray = document.getElementById("cameraLookAt").value;
       let antialiased = document.getElementById("antialiased").checked;
+      let sphericalHarmonicsLevel = parseInt(document.getElementById("viewSphericalHarmonicsLevel").value);
 
       cameraUpArray = cameraUpArray.split(',');
       cameraPositionArray = cameraPositionArray.split(',');
@@ -438,7 +444,10 @@
       } else if (isNaN(alphaRemovalThreshold) || alphaRemovalThreshold < 0 || alphaRemovalThreshold > 255) {
         setViewError("Invalid alpha remval threshold.");
         return;
-      }
+      } else if (isNaN(sphericalHarmonicsLevel) || sphericalHarmonicsLevel < 0 || sphericalHarmonicsLevel > 3) {
+        setConversionError("Invalid SH level.");
+        return;
+      } 
 
       if (cameraUpArray.length !== 3) {
         setViewError("Camera up must contain 3 elements.");
@@ -484,12 +493,13 @@
       currentCameraPositionArray = cameraPositionArray;
       currentCameraLookAtArray = cameraLookAtArray;
       currentAntialiased = antialiased;
+      currentSphericalHarmonicsLevel = sphericalHarmonicsLevel;
 
       try {
         const fileReader = new FileReader();
         fileReader.onload = function(){
           try {
-           runViewer(fileReader.result, format, alphaRemovalThreshold, cameraUpArray, cameraPositionArray, cameraLookAtArray, antialiased);
+           runViewer(fileReader.result, format, alphaRemovalThreshold, cameraUpArray, cameraPositionArray, cameraLookAtArray, antialiased, sphericalHarmonicsLevel);
           } catch (e) {
             console.error(e);
             setViewError("Could not view scene.");
@@ -521,13 +531,13 @@
   
     window.addEventListener("popstate", (event) => {
       if (currentAlphaRemovalThreshold !== undefined) {
-        window.location = 'index.html?art=' + currentAlphaRemovalThreshold + '&cu=' + currentCameraUpArray + "&cp=" + currentCameraPositionArray + "&cla=" + currentCameraLookAtArray + "&aa=" + currentAntialiased;
+        window.location = 'index.html?art=' + currentAlphaRemovalThreshold + '&cu=' + currentCameraUpArray + "&cp=" + currentCameraPositionArray + "&cla=" + currentCameraLookAtArray + "&aa=" + currentAntialiased + "&sh=" + currentSphericalHarmonicsLevel;
       } else {
         window.location = 'index.html';
       }
     });
 
-    function runViewer(splatBufferData, format, alphaRemovalThreshold, cameraUpArray, cameraPositionArray, cameraLookAtArray, antialiased) {
+    function runViewer(splatBufferData, format, alphaRemovalThreshold, cameraUpArray, cameraPositionArray, cameraLookAtArray, antialiased, sphericalHarmonicsLevel) {
       const viewerOptions = {
         'cameraUp': cameraUpArray,
         'initialCameraPosition': cameraPositionArray,
@@ -538,7 +548,8 @@
       const splatBufferOptions = {
         'splatAlphaRemovalThreshold': alphaRemovalThreshold
       };
-      const splatBufferPromise = fileBufferToSplatBuffer({data: splatBufferData}, format, alphaRemovalThreshold, 0);
+      const splatBufferPromise = fileBufferToSplatBuffer({data: splatBufferData}, format, alphaRemovalThreshold, 0,
+                                                          undefined, undefined, undefined, undefined, sphericalHarmonicsLevel);
       splatBufferPromise.then((splatBuffer) => {
         document.getElementById("demo-content").style.display = 'none';
         document.body.style.backgroundColor = "#000000";
@@ -617,7 +628,7 @@
     <br>
     <div class="header-content-container">
         <div class="content-row">
-            <div id ="view-panel" class="splat-panel" style="height:330px;">
+            <div id ="view-panel" class="splat-panel" style="height:350px;">
                 <br>
                 <div class="small-title">View a <span class="file-ext">.ply</span>, <span class="file-ext">.ksplat</span>, or <span class="file-ext-small">.splat</span> file</div>
                 <br>
@@ -674,6 +685,15 @@
                         <input id="cameraLookAt" type="text" class="text-input" style="width: 90px" value="1, 0, 0"></input>
                     </td>
                     </tr>
+                    <tr>
+                      <td>
+                          SH level:
+                      </td>
+                      <td>
+                          <input id="viewSphericalHarmonicsLevel" type="text" class="text-input" style="width: 50px" value="0"></input>
+                          <span class="valid-value-label">(0, 1, 2, or 3)</span>
+                      </td>
+                      </tr>
                 </table>
                 <br>
                 <span class="button" onclick="window.viewSplat()">View</span>
@@ -691,7 +711,7 @@
                 <span id="viewError" style="color: #ff0000"></span>
             </div>
       
-            <div id ="conversion-panel" class="splat-panel" style="height:390px;">
+            <div id ="conversion-panel" class="splat-panel" style="height:420px;">
                 <br>
                 <span class="small-title">Convert a <span class="file-ext">.ply</span> or <span class="file-ext">.splat</span> to <span class="file-ext">.ksplat</span></span>
                 <br>
@@ -733,6 +753,15 @@
                     <td>
                         <input id="compressionLevel" type="text" class="text-input" style="width: 50px" value="1" onChange="window.onCompressionLevelChange(this);"></input>
                         <span class="valid-value-label">(0 or 1)</span>
+                    </td>
+                    </tr>
+                    <tr>
+                    <td>
+                        SH level:
+                    </td>
+                    <td>
+                        <input id="conversionSphericalHarmonicsLevel" type="text" class="text-input" style="width: 50px" value="0"></input>
+                        <span class="valid-value-label">(0, 1, 2, or 3)</span>
                     </td>
                     </tr>
                     <tr id="advancedCompressionRow1">
@@ -893,6 +922,9 @@
         } else if (varName == "aa") {
           currentAntialiased = component[1] === 'true' ? true : false;
           document.getElementById('antialiased').checked = currentAntialiased;
+        }  else if (varName == "sh") {
+          currentSphericalHarmonicsLevel = component[1];
+          document.getElementById('viewSphericalHarmonicsLevel').value = currentSphericalHarmonicsLevel;
         }
       }
     }

--- a/demo/index.html
+++ b/demo/index.html
@@ -262,15 +262,15 @@
     let currentCameraPositionArray;
     let currentCameraLookAtArray;
     let currentAntialiased;
-    let currentSphericalHarmonicsLevel;
+    let currentSphericalHarmonicsDegree;
   </script>
   <script type="module">
     import * as GaussianSplats3D from 'gaussian-splats-3d';
     import * as THREE from 'three';
 
-    function fileBufferToSplatBuffer(fileBufferData, format, alphaRemovalThreshold, compressionLevel, sectionSize, sceneCenter, blockSize, bucketSize, outSphericalHarmonicsLevel = 0) {
+    function fileBufferToSplatBuffer(fileBufferData, format, alphaRemovalThreshold, compressionLevel, sectionSize, sceneCenter, blockSize, bucketSize, outSphericalHarmonicsDegree = 0) {
       if (format === GaussianSplats3D.SceneFormat.Ply) {
-        return GaussianSplats3D.PlyLoader.loadFromFileData(fileBufferData.data, alphaRemovalThreshold, compressionLevel, sectionSize, sceneCenter, blockSize, bucketSize, outSphericalHarmonicsLevel);
+        return GaussianSplats3D.PlyLoader.loadFromFileData(fileBufferData.data, alphaRemovalThreshold, compressionLevel, sectionSize, sceneCenter, blockSize, bucketSize, outSphericalHarmonicsDegree);
       } else {
         if (format === GaussianSplats3D.SceneFormat.Splat) {
           return GaussianSplats3D.SplatLoader.loadFromFileData(fileBufferData.data, alphaRemovalThreshold, compressionLevel, sectionSize, sceneCenter, blockSize, bucketSize);
@@ -311,7 +311,7 @@
       const conversionFile = document.getElementById("conversionFile");
       const compressionLevel = parseInt(document.getElementById("compressionLevel").value);
       const alphaRemovalThreshold = parseInt(document.getElementById("alphaRemovalThreshold").value);
-      const sphericalHarmonicsLevel = parseInt(document.getElementById("conversionSphericalHarmonicsLevel").value);
+      const sphericalHarmonicsDegree = parseInt(document.getElementById("conversionSphericalHarmonicsDegree").value);
       const sectionSize = 0;
       let sceneCenterArray = document.getElementById("sceneCenter").value;
       const blockSize = parseFloat(document.getElementById("blockSize").value);
@@ -341,7 +341,7 @@
       } else if (isNaN(alphaRemovalThreshold) || alphaRemovalThreshold <0 || alphaRemovalThreshold > 255) {
         setConversionError("Invalid alpha remval threshold.");
         return;
-      } else if (isNaN(sphericalHarmonicsLevel) || sphericalHarmonicsLevel < 0 || sphericalHarmonicsLevel > 3) {
+      } else if (isNaN(sphericalHarmonicsDegree) || sphericalHarmonicsDegree < 0 || sphericalHarmonicsDegree > 3) {
         setConversionError("Invalid SH level.");
         return;
       } else if (isNaN(blockSize) || blockSize < 0.1) {
@@ -384,7 +384,7 @@
           window.setTimeout(() => {
             try {
               const splatBufferPromise = fileBufferToSplatBuffer(fileData, format, alphaRemovalThreshold, compressionLevel,
-                                                                 sectionSize, sceneCenter, blockSize, bucketSize, sphericalHarmonicsLevel);
+                                                                 sectionSize, sceneCenter, blockSize, bucketSize, sphericalHarmonicsDegree);
               splatBufferPromise.then((splatBuffer) => {
                 GaussianSplats3D.KSplatLoader.downloadFile(splatBuffer, 'converted_file.ksplat');
                 conversionDone();
@@ -432,7 +432,7 @@
       let cameraPositionArray = document.getElementById("cameraPosition").value;
       let cameraLookAtArray = document.getElementById("cameraLookAt").value;
       let antialiased = document.getElementById("antialiased").checked;
-      let sphericalHarmonicsLevel = parseInt(document.getElementById("viewSphericalHarmonicsLevel").value);
+      let sphericalHarmonicsDegree = parseInt(document.getElementById("viewSphericalHarmonicsDegree").value);
 
       cameraUpArray = cameraUpArray.split(',');
       cameraPositionArray = cameraPositionArray.split(',');
@@ -444,7 +444,7 @@
       } else if (isNaN(alphaRemovalThreshold) || alphaRemovalThreshold < 0 || alphaRemovalThreshold > 255) {
         setViewError("Invalid alpha remval threshold.");
         return;
-      } else if (isNaN(sphericalHarmonicsLevel) || sphericalHarmonicsLevel < 0 || sphericalHarmonicsLevel > 3) {
+      } else if (isNaN(sphericalHarmonicsDegree) || sphericalHarmonicsDegree < 0 || sphericalHarmonicsDegree > 3) {
         setConversionError("Invalid SH level.");
         return;
       } 
@@ -493,13 +493,13 @@
       currentCameraPositionArray = cameraPositionArray;
       currentCameraLookAtArray = cameraLookAtArray;
       currentAntialiased = antialiased;
-      currentSphericalHarmonicsLevel = sphericalHarmonicsLevel;
+      currentSphericalHarmonicsDegree = sphericalHarmonicsDegree;
 
       try {
         const fileReader = new FileReader();
         fileReader.onload = function(){
           try {
-           runViewer(fileReader.result, format, alphaRemovalThreshold, cameraUpArray, cameraPositionArray, cameraLookAtArray, antialiased, sphericalHarmonicsLevel);
+           runViewer(fileReader.result, format, alphaRemovalThreshold, cameraUpArray, cameraPositionArray, cameraLookAtArray, antialiased, sphericalHarmonicsDegree);
           } catch (e) {
             console.error(e);
             setViewError("Could not view scene.");
@@ -531,13 +531,13 @@
   
     window.addEventListener("popstate", (event) => {
       if (currentAlphaRemovalThreshold !== undefined) {
-        window.location = 'index.html?art=' + currentAlphaRemovalThreshold + '&cu=' + currentCameraUpArray + "&cp=" + currentCameraPositionArray + "&cla=" + currentCameraLookAtArray + "&aa=" + currentAntialiased + "&sh=" + currentSphericalHarmonicsLevel;
+        window.location = 'index.html?art=' + currentAlphaRemovalThreshold + '&cu=' + currentCameraUpArray + "&cp=" + currentCameraPositionArray + "&cla=" + currentCameraLookAtArray + "&aa=" + currentAntialiased + "&sh=" + currentSphericalHarmonicsDegree;
       } else {
         window.location = 'index.html';
       }
     });
 
-    function runViewer(splatBufferData, format, alphaRemovalThreshold, cameraUpArray, cameraPositionArray, cameraLookAtArray, antialiased, sphericalHarmonicsLevel) {
+    function runViewer(splatBufferData, format, alphaRemovalThreshold, cameraUpArray, cameraPositionArray, cameraLookAtArray, antialiased, sphericalHarmonicsDegree) {
       const viewerOptions = {
         'cameraUp': cameraUpArray,
         'initialCameraPosition': cameraPositionArray,
@@ -549,7 +549,7 @@
         'splatAlphaRemovalThreshold': alphaRemovalThreshold
       };
       const splatBufferPromise = fileBufferToSplatBuffer({data: splatBufferData}, format, alphaRemovalThreshold, 0,
-                                                          undefined, undefined, undefined, undefined, sphericalHarmonicsLevel);
+                                                          undefined, undefined, undefined, undefined, sphericalHarmonicsDegree);
       splatBufferPromise.then((splatBuffer) => {
         document.getElementById("demo-content").style.display = 'none';
         document.body.style.backgroundColor = "#000000";
@@ -690,7 +690,7 @@
                           SH level:
                       </td>
                       <td>
-                          <input id="viewSphericalHarmonicsLevel" type="text" class="text-input" style="width: 50px" value="0"></input>
+                          <input id="viewSphericalHarmonicsDegree" type="text" class="text-input" style="width: 50px" value="0"></input>
                           <span class="valid-value-label">(0, 1, 2, or 3)</span>
                       </td>
                       </tr>
@@ -760,7 +760,7 @@
                         SH level:
                     </td>
                     <td>
-                        <input id="conversionSphericalHarmonicsLevel" type="text" class="text-input" style="width: 50px" value="0"></input>
+                        <input id="conversionSphericalHarmonicsDegree" type="text" class="text-input" style="width: 50px" value="0"></input>
                         <span class="valid-value-label">(0, 1, 2, or 3)</span>
                     </td>
                     </tr>
@@ -923,8 +923,8 @@
           currentAntialiased = component[1] === 'true' ? true : false;
           document.getElementById('antialiased').checked = currentAntialiased;
         }  else if (varName == "sh") {
-          currentSphericalHarmonicsLevel = component[1];
-          document.getElementById('viewSphericalHarmonicsLevel').value = currentSphericalHarmonicsLevel;
+          currentSphericalHarmonicsDegree = component[1];
+          document.getElementById('viewSphericalHarmonicsDegree').value = currentSphericalHarmonicsDegree;
         }
       }
     }

--- a/demo/index.html
+++ b/demo/index.html
@@ -270,7 +270,7 @@
 
     function fileBufferToSplatBuffer(fileBufferData, format, alphaRemovalThreshold, compressionLevel, sectionSize, sceneCenter, blockSize, bucketSize, outSphericalHarmonicsDegree = 0) {
       if (format === GaussianSplats3D.SceneFormat.Ply) {
-        return GaussianSplats3D.PlyLoader.loadFromFileData(fileBufferData.data, alphaRemovalThreshold, compressionLevel, sectionSize, sceneCenter, blockSize, bucketSize, outSphericalHarmonicsDegree);
+        return GaussianSplats3D.PlyLoader.loadFromFileData(fileBufferData.data, alphaRemovalThreshold, compressionLevel, outSphericalHarmonicsDegree, sectionSize, sceneCenter, blockSize, bucketSize);
       } else {
         if (format === GaussianSplats3D.SceneFormat.Splat) {
           return GaussianSplats3D.SplatLoader.loadFromFileData(fileBufferData.data, alphaRemovalThreshold, compressionLevel, sectionSize, sceneCenter, blockSize, bucketSize);

--- a/demo/stump.html
+++ b/demo/stump.html
@@ -30,13 +30,17 @@
 <body>
   <script type="module">
     import * as GaussianSplats3D from '@mkkellogg/gaussian-splats-3d';
+
+    const urlParams = new URLSearchParams(window.location.search);
+    const mode = parseInt(urlParams.get('mode')) || 0;
+
     const viewer = new GaussianSplats3D.Viewer({
         'cameraUp': [0, -1, -1.0],
         'initialCameraPosition': [-3.3816, 1.96931, -1.71890],
-        'initialCameraLookAt': [-0.04979, 1.37519, 1.13443]
+        'initialCameraLookAt': [-0.04979, 1.37519, 1.13443],
+        'sphericalHarmonicsDegree': 2
     });
-    let path = 'assets/data/stump/stump';
-    path += isMobile() ? '.ksplat' : '_high.ksplat';
+    let path = 'assets/data/stump/stump' + (mode ? '_high' : '') + '.ksplat';
     viewer.addSplatScene(path, {
       'streamView': true
     })

--- a/demo/truck.html
+++ b/demo/truck.html
@@ -30,13 +30,17 @@
 <body>
   <script type="module">
     import * as GaussianSplats3D from '@mkkellogg/gaussian-splats-3d';
+
+    const urlParams = new URLSearchParams(window.location.search);
+    const mode = parseInt(urlParams.get('mode')) || 0;
+
     const viewer = new GaussianSplats3D.Viewer({
         'cameraUp': [0, -1, -.17],
         'initialCameraPosition': [-5, -1, -1],
-        'initialCameraLookAt': [-1.72477, 0.05395, -0.00147]
+        'initialCameraLookAt': [-1.72477, 0.05395, -0.00147],
+        'sphericalHarmonicsDegree': 2
     });
-    let path = 'assets/data/truck/truck';
-    path += isMobile() ? '.ksplat' : '_high.ksplat';
+    let path = 'assets/data/truck/truck' + (mode ? '_high' : '') + '.ksplat';
     viewer.addSplatScene(path, {
       'streamView': true
     })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@mkkellogg/gaussian-splats-3d",
-    "version": "0.3.9",
+    "version": "0.4.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@mkkellogg/gaussian-splats-3d",
-            "version": "0.3.9",
+            "version": "0.4.0",
             "license": "MIT",
             "devDependencies": {
                 "@babel/core": "7.22.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
         "type": "git",
         "url": "https://github.com/mkkellogg/GaussianSplats3D"
     },
-    "version": "0.3.9",
+    "version": "0.4.0",
     "description": "Three.js-based 3D Gaussian splat viewer",
     "module": "build/gaussian-splats-3d.module.js",
     "main": "build/gaussian-splats-3d.umd.cjs",

--- a/src/Constants.js
+++ b/src/Constants.js
@@ -6,5 +6,4 @@ export class Constants {
     static BytesPerInt = 4;
     static MaxScenes = 32;
     static StreamingSectionSize = 524288;
-
 }

--- a/src/SplatMesh.js
+++ b/src/SplatMesh.js
@@ -1100,8 +1100,8 @@ export class SplatMesh extends THREE.Mesh {
 
         // set up covariances data texture
         const covTexSize = computeDataTextureSize(COVARIANCES_ELEMENTS_PER_TEXEL, 6);
-        let CovariancesDataType = covarianceCompressionLevel === 1 ? Uint16Array : Float32Array;
-        let covariancesTextureType = covarianceCompressionLevel === 1 ? THREE.HalfFloatType : THREE.FloatType;
+        let CovariancesDataType = covarianceCompressionLevel >= 1 ? Uint16Array : Float32Array;
+        let covariancesTextureType = covarianceCompressionLevel >= 1 ? THREE.HalfFloatType : THREE.FloatType;
         const paddedCovariances = new CovariancesDataType(covTexSize.x * covTexSize.y * COVARIANCES_ELEMENTS_PER_TEXEL);
         paddedCovariances.set(covariances);
 

--- a/src/SplatMesh.js
+++ b/src/SplatMesh.js
@@ -1042,7 +1042,7 @@ export class SplatMesh extends THREE.Mesh {
             const sphericalHarmonicsTexSize = computeDataTextureSize(SPHERICAL_HARMONICS_ELEMENTS_PER_TEXEL,
                                                                      paddedSphericalHarmonicsComponentCount);
             const paddedSHArraySize = sphericalHarmonicsTexSize.x * sphericalHarmonicsTexSize.y * SPHERICAL_HARMONICS_ELEMENTS_PER_TEXEL;
-            const paddedSHArray = new Float32Array(paddedSHArraySize);
+            const paddedSHArray = new Uint16Array(paddedSHArraySize);
             for (let c = 0; c < splatCount; c++) {
                 const srcBase = sphericalHarmonicsComponentCount * c;
                 const destBase = paddedSphericalHarmonicsComponentCount * c;
@@ -1051,7 +1051,7 @@ export class SplatMesh extends THREE.Mesh {
                 }
             }
             const sphericalHarmonicsTex = new THREE.DataTexture(paddedSHArray, sphericalHarmonicsTexSize.x,
-                                                                sphericalHarmonicsTexSize.y, THREE.RGFormat, THREE.FloatType);
+                                                                sphericalHarmonicsTexSize.y, THREE.RGFormat, THREE.HalfFloatType);
             sphericalHarmonicsTex.needsUpdate = true;
             this.material.uniforms.sphericalHarmonicsTexture.value = sphericalHarmonicsTex;
             this.material.uniforms.sphericalHarmonicsTextureSize.value.copy(sphericalHarmonicsTexSize);
@@ -1146,7 +1146,7 @@ export class SplatMesh extends THREE.Mesh {
                 sphericalHarmonicsTex.needsUpdate = true;
             } else {
                 this.updateDataTexture(paddedSHArray, sphericalHarmonicsTexDesc, sphericalHarmonicsTextureProps,
-                                       SPHERICAL_HARMONICS_ELEMENTS_PER_TEXEL, paddedSphericalHarmonicsComponentCount, 4,
+                                       SPHERICAL_HARMONICS_ELEMENTS_PER_TEXEL, paddedSphericalHarmonicsComponentCount, 2,
                                        this.lastBuildSplatCount, splatCount - 1);
             }
         }

--- a/src/SplatMesh.js
+++ b/src/SplatMesh.js
@@ -829,8 +829,9 @@ export class SplatMesh extends THREE.Mesh {
 
         let minSphericalHarmonicsDegree = 1000;
         for (let splatBuffer of splatBuffers) {
-            if (splatBuffer.sphericalHarmonicsDegree < minSphericalHarmonicsDegree) {
-                minSphericalHarmonicsDegree = splatBuffer.sphericalHarmonicsDegree;
+            const splatBufferSphericalHarmonicsDegree = splatBuffer.getMinSphericalHarmonicsDegree();
+            if (splatBufferSphericalHarmonicsDegree < minSphericalHarmonicsDegree) {
+                minSphericalHarmonicsDegree = splatBufferSphericalHarmonicsDegree;
             }
         }
         this.minSphericalHarmonicsDegree = Math.min(minSphericalHarmonicsDegree, this.sphericalHarmonicsDegree);

--- a/src/SplatMesh.js
+++ b/src/SplatMesh.js
@@ -230,6 +230,9 @@ export class SplatMesh extends THREE.Mesh {
 
                 if (sphericalHarmonicsDegree >= 1) {
                     vec3 worldViewDir = normalize(splatCenter - cameraPosition);
+                    float x = worldViewDir.x;
+                    float y = worldViewDir.y;
+                    float z = worldViewDir.z;
                 `;
 
             if (dynamicMode) {
@@ -238,6 +241,7 @@ export class SplatMesh extends THREE.Mesh {
                 `;
             }
 
+            // res += SH_C1 * (-splat.sh1 * y + splat.sh2 * z - splat.sh3 * x);
             vertexShaderSource += `
                     vec2 sampledSH01 = texture(sphericalHarmonicsTexture, getDataUV(5, 0, sphericalHarmonicsTextureSize)).rg;
                     vec2 sampledSH23 = texture(sphericalHarmonicsTexture, getDataUV(5, 1, sphericalHarmonicsTextureSize)).rg;
@@ -245,9 +249,9 @@ export class SplatMesh extends THREE.Mesh {
                     vec2 sampledSH67 = texture(sphericalHarmonicsTexture, getDataUV(5, 3, sphericalHarmonicsTextureSize)).rg;
                     vec2 sampledSH89 = texture(sphericalHarmonicsTexture, getDataUV(5, 4, sphericalHarmonicsTextureSize)).rg;
                     float SH_C1 = 0.4886025119029199f;
-                    vColor.r = vColor.r + dot(vec3(sampledSH01.r, sampledSH01.g, sampledSH23.r), worldViewDir.xyz) * SH_C1;
-                    vColor.g = vColor.g + dot(vec3(sampledSH23.g, sampledSH45.r, sampledSH45.g), worldViewDir.xyz) * SH_C1;
-                    vColor.b = vColor.b + dot(vec3(sampledSH67.r, sampledSH67.g, sampledSH89.r), worldViewDir.xyz) * SH_C1;
+                    vColor.rgb += SH_C1 * (-vec3(sampledSH01.r, sampledSH23.g, sampledSH67.r) * y +
+                                            vec3(sampledSH01.g, sampledSH45.r, sampledSH67.g) * z -
+                                            vec3(sampledSH23.r, sampledSH45.g, sampledSH89.r) * x);
                 }
 
                 uint oddOffset = splatIndex & uint(0x00000001);

--- a/src/SplatMesh.js
+++ b/src/SplatMesh.js
@@ -230,15 +230,24 @@ export class SplatMesh extends THREE.Mesh {
 
                 if (sphericalHarmonicsDegree >= 1) {
                     vec3 worldViewDir = normalize(splatCenter - cameraPosition);
+                `;
+
+            if (dynamicMode) {
+                vertexShaderSource += `
+                worldViewDir = inverse(mat3(transform)) * worldViewDir;
+                `;
+            }
+
+            vertexShaderSource += `
                     vec2 sampledSH01 = texture(sphericalHarmonicsTexture, getDataUV(5, 0, sphericalHarmonicsTextureSize)).rg;
                     vec2 sampledSH23 = texture(sphericalHarmonicsTexture, getDataUV(5, 1, sphericalHarmonicsTextureSize)).rg;
                     vec2 sampledSH45 = texture(sphericalHarmonicsTexture, getDataUV(5, 2, sphericalHarmonicsTextureSize)).rg;
                     vec2 sampledSH67 = texture(sphericalHarmonicsTexture, getDataUV(5, 3, sphericalHarmonicsTextureSize)).rg;
                     vec2 sampledSH89 = texture(sphericalHarmonicsTexture, getDataUV(5, 4, sphericalHarmonicsTextureSize)).rg;
                     float SH_C1 = 0.4886025119029199f;
-                    vColor.r = vColor.r + dot(vec3(-sampledSH01.r, sampledSH23.g, -sampledSH67.r), worldViewDir.yzx) * SH_C1;
-                    vColor.g = vColor.g + dot(vec3(-sampledSH01.g, sampledSH45.r, -sampledSH67.g), worldViewDir.yzx) * SH_C1;
-                    vColor.b = vColor.b + dot(vec3(-sampledSH23.r, sampledSH45.g, -sampledSH89.r), worldViewDir.yzx) * SH_C1;
+                    vColor.r = vColor.r + dot(vec3(sampledSH01.r, sampledSH01.g, sampledSH23.r), worldViewDir.xyz) * SH_C1;
+                    vColor.g = vColor.g + dot(vec3(sampledSH23.g, sampledSH45.r, sampledSH45.g), worldViewDir.xyz) * SH_C1;
+                    vColor.b = vColor.b + dot(vec3(sampledSH67.r, sampledSH67.g, sampledSH89.r), worldViewDir.xyz) * SH_C1;
                 }
 
                 uint oddOffset = splatIndex & uint(0x00000001);

--- a/src/SplatMesh.js
+++ b/src/SplatMesh.js
@@ -233,16 +233,19 @@ export class SplatMesh extends THREE.Mesh {
                 vColor = uintToRGBAVec(sampledCenterColor.r);
 
                 if (sphericalHarmonicsDegree >= 1) {
-                    vec3 worldViewDir = normalize(splatCenter - cameraPosition);
                 `;
 
-            if (dynamicMode) {
+           if (dynamicMode) {
                 vertexShaderSource += `
-                worldViewDir = normalize(inverse(mat3(transform)) * worldViewDir);
+                mat4 mTransform = modelMatrix * transform;
+                vec3 worldViewDir = normalize(splatCenter - vec3(inverse(mTransform) * vec4(cameraPosition, 1.0)));
+                `;
+            } else {
+                vertexShaderSource += `
+                vec3 worldViewDir = normalize(splatCenter - cameraPosition);
                 `;
             }
 
-            // res += SH_C1 * (-splat.sh1 * y + splat.sh2 * z - splat.sh3 * x);
             vertexShaderSource += `
                     const int[2] strides = int[](5, 12);
                     int stride = strides[sphericalHarmonicsDegree - 1];

--- a/src/SplatMesh.js
+++ b/src/SplatMesh.js
@@ -2045,7 +2045,7 @@ export class SplatMesh extends THREE.Mesh {
                                                      srcStart, srcEnd, destStart, covarianceCompressionLevel);
             }
             if (centers) splatBuffer.fillSplatCenterArray(centers, sceneTransform, srcStart, srcEnd, destStart);
-            if (colors) splatBuffer.fillSplatColorArray(colors, scene.minimumAlpha, sceneTransform, srcStart, srcEnd, destStart);
+            if (colors) splatBuffer.fillSplatColorArray(colors, scene.minimumAlpha, srcStart, srcEnd, destStart);
             if (sphericalHarmonics) {
                 splatBuffer.fillSphericalHarmonicsArray(sphericalHarmonics, this.minSphericalHarmonicsDegree,
                                                         sceneTransform, srcStart, srcEnd, destStart, sphericalHarmonicsCompressionLevel);
@@ -2153,7 +2153,7 @@ export class SplatMesh extends THREE.Mesh {
 
         return function(globalIndex, outColor) {
             this.getLocalSplatParameters(globalIndex, paramsObj);
-            paramsObj.splatBuffer.getSplatColor(paramsObj.localIndex, outColor, paramsObj.sceneTransform);
+            paramsObj.splatBuffer.getSplatColor(paramsObj.localIndex, outColor);
         };
 
     }();

--- a/src/SplatMesh.js
+++ b/src/SplatMesh.js
@@ -230,28 +230,28 @@ export class SplatMesh extends THREE.Mesh {
 
                 if (sphericalHarmonicsDegree >= 1) {
                     vec3 worldViewDir = normalize(splatCenter - cameraPosition);
-                    float x = worldViewDir.x;
-                    float y = worldViewDir.y;
-                    float z = worldViewDir.z;
                 `;
 
             if (dynamicMode) {
                 vertexShaderSource += `
-                worldViewDir = inverse(mat3(transform)) * worldViewDir;
+                worldViewDir = normalize(inverse(mat3(transform)) * worldViewDir);
                 `;
             }
 
             // res += SH_C1 * (-splat.sh1 * y + splat.sh2 * z - splat.sh3 * x);
             vertexShaderSource += `
+                    float x = worldViewDir.x;
+                    float y = worldViewDir.y;
+                    float z = worldViewDir.z;
                     vec2 sampledSH01 = texture(sphericalHarmonicsTexture, getDataUV(5, 0, sphericalHarmonicsTextureSize)).rg;
                     vec2 sampledSH23 = texture(sphericalHarmonicsTexture, getDataUV(5, 1, sphericalHarmonicsTextureSize)).rg;
                     vec2 sampledSH45 = texture(sphericalHarmonicsTexture, getDataUV(5, 2, sphericalHarmonicsTextureSize)).rg;
                     vec2 sampledSH67 = texture(sphericalHarmonicsTexture, getDataUV(5, 3, sphericalHarmonicsTextureSize)).rg;
                     vec2 sampledSH89 = texture(sphericalHarmonicsTexture, getDataUV(5, 4, sphericalHarmonicsTextureSize)).rg;
                     float SH_C1 = 0.4886025119029199f;
-                    vColor.rgb += SH_C1 * (-vec3(sampledSH01.r, sampledSH23.g, sampledSH67.r) * y +
-                                            vec3(sampledSH01.g, sampledSH45.r, sampledSH67.g) * z -
-                                            vec3(sampledSH23.r, sampledSH45.g, sampledSH89.r) * x);
+                    vColor.rgb += SH_C1 * (-vec3(sampledSH01.r, sampledSH01.g, sampledSH23.r) * y +
+                                            vec3(sampledSH23.g, sampledSH45.r, sampledSH45.g) * z -
+                                            vec3(sampledSH67.r, sampledSH67.g, sampledSH89.r) * x);
                 }
 
                 uint oddOffset = splatIndex & uint(0x00000001);
@@ -994,7 +994,7 @@ export class SplatMesh extends THREE.Mesh {
         let paddedSphericalHarmonicsComponentCount = sphericalHarmonicsComponentCount;
         if (paddedSphericalHarmonicsComponentCount % 2 !== 0) paddedSphericalHarmonicsComponentCount++;
         const sphericalHarmonics = this.sphericalHarmonicsDegree ?
-                                   new Float32Array(maxSplatCount * sphericalHarmonicsComponentCount) : undefined;
+                                   new Uint16Array(maxSplatCount * sphericalHarmonicsComponentCount) : undefined;
         this.fillSplatDataArrays(covariances, centers, colors, sphericalHarmonics);
 
         // set up covariances data texture

--- a/src/SplatMesh.js
+++ b/src/SplatMesh.js
@@ -1291,8 +1291,11 @@ export class SplatMesh extends THREE.Mesh {
     }
 
     getTargetCovarianceCompressionLevel() {
-        const baseCompressionLevel = this.halfPrecisionCovariancesOnGPU ? 1 : 0;
-        return Math.max(baseCompressionLevel, this.getMaximumSplatBufferCompressionLevel());
+        if (this.halfPrecisionCovariancesOnGPU) {
+            return Math.max(1, this.getMaximumSplatBufferCompressionLevel());
+        } else {
+            return 0;
+        }
     }
 
     getTargetSphericalHarmonicsCompressionLevel() {

--- a/src/SplatMesh.js
+++ b/src/SplatMesh.js
@@ -202,6 +202,7 @@ export class SplatMesh extends THREE.Mesh {
 
             const float SH_C1 = 0.4886025119029199f;
             const float[5] SH_C2 = float[](1.0925484, -1.0925484, 0.3153916, -1.0925484, 0.5462742);
+            const vec3 vecOnes3 = vec3(1.0, 1.0, 1.0);
 
             void main () {
 
@@ -283,9 +284,9 @@ export class SplatMesh extends THREE.Mesh {
 
                 vertexShaderSource += `
                         if (sphericalHarmonics8BitMode == 1) {
-                            sh1 = sh1 * 2.0 - vec3(1.0, 1.0, 1.0);
-                            sh2 = sh2 * 2.0 - vec3(1.0, 1.0, 1.0);
-                            sh3 = sh3 * 2.0 - vec3(1.0, 1.0, 1.0);
+                            sh1 = sh1 * 2.0 - vecOnes3;
+                            sh2 = sh2 * 2.0 - vecOnes3;
+                            sh3 = sh3 * 2.0 - vecOnes3;
                         }
                         float x = worldViewDir.x;
                         float y = worldViewDir.y;
@@ -315,11 +316,11 @@ export class SplatMesh extends THREE.Mesh {
                             vec3 sh8 = sampledSH20212223.gba;
 
                             if (sphericalHarmonics8BitMode == 1) {
-                                sh4 = sh4 * 2.0 - vec3(1.0, 1.0, 1.0);
-                                sh5 = sh5 * 2.0 - vec3(1.0, 1.0, 1.0);
-                                sh6 = sh6 * 2.0 - vec3(1.0, 1.0, 1.0);
-                                sh7 = sh7 * 2.0 - vec3(1.0, 1.0, 1.0);
-                                sh8 = sh8 * 2.0 - vec3(1.0, 1.0, 1.0);
+                                sh4 = sh4 * 2.0 - vecOnes3;
+                                sh5 = sh5 * 2.0 - vecOnes3;
+                                sh6 = sh6 * 2.0 - vecOnes3;
+                                sh7 = sh7 * 2.0 - vecOnes3;
+                                sh8 = sh8 * 2.0 - vecOnes3;
                             }
 
                             vColor.rgb +=

--- a/src/SplatMesh.js
+++ b/src/SplatMesh.js
@@ -62,7 +62,6 @@ export class SplatMesh extends THREE.Mesh {
         this.logLevel = logLevel;
         // Level 0 means no spherical harmonics
         this.sphericalHarmonicsDegree = sphericalHarmonicsDegree;
-        console.log(sphericalHarmonicsDegree)
         // The individual splat scenes stored in this splat mesh, each containing their own transform
         this.scenes = [];
         // Special octree tailored to SplatMesh instances
@@ -942,7 +941,8 @@ export class SplatMesh extends THREE.Mesh {
         const centers = new Float32Array(maxSplatCount * 3);
         const colors = new Uint8Array(maxSplatCount * 4);
         const sphericalHarmonicsComponentCount = getSphericalHarmonicsComponentCountForDegree(this.sphericalHarmonicsDegree);
-        const sphericalHarmonics = this.sphericalHarmonicsDegree ? new Float32Array(maxSplatCount * sphericalHarmonicsComponentCount) : undefined;
+        const sphericalHarmonics = this.sphericalHarmonicsDegree ?
+                                   new Float32Array(maxSplatCount * sphericalHarmonicsComponentCount) : undefined;
         this.fillSplatDataArrays(covariances, centers, colors, sphericalHarmonics);
 
         // set up covariances data texture
@@ -1798,6 +1798,7 @@ export class SplatMesh extends THREE.Mesh {
      * @param {Float32Array} covariances Target storage for splat covariances
      * @param {Float32Array} centers Target storage for splat centers
      * @param {Uint8Array} colors Target storage for splat colors
+     * @param {Float32Array} sphericalHarmonics Target storage for spherical harmonics
      * @param {boolean} applySceneTransform By default, scene transforms are applied to relevant splat data only if the splat mesh is
      *                                      static. If 'applySceneTransform' is true, scene transforms will always be applied and if
      *                                      it is false, they will never be applied. If undefined, the default behavior will apply.

--- a/src/Util.js
+++ b/src/Util.js
@@ -145,3 +145,12 @@ export const delayedExecute = (func, fast) => {
         }, fast ? 1 : 50);
     });
 };
+
+
+export const getSphericalHarmonicsComponentCountForDegree = (sphericalHarmonicsDegree = 0) => {
+    switch(sphericalHarmonicsDegree) {
+        case 1:
+            return 9;
+    }
+    return 0;
+};

--- a/src/Util.js
+++ b/src/Util.js
@@ -151,6 +151,8 @@ export const getSphericalHarmonicsComponentCountForDegree = (sphericalHarmonicsD
     switch (sphericalHarmonicsDegree) {
         case 1:
             return 9;
+        case 2:
+            return 24;
     }
     return 0;
 };

--- a/src/Util.js
+++ b/src/Util.js
@@ -148,7 +148,7 @@ export const delayedExecute = (func, fast) => {
 
 
 export const getSphericalHarmonicsComponentCountForDegree = (sphericalHarmonicsDegree = 0) => {
-    switch(sphericalHarmonicsDegree) {
+    switch (sphericalHarmonicsDegree) {
         case 1:
             return 9;
     }

--- a/src/Viewer.js
+++ b/src/Viewer.js
@@ -141,7 +141,7 @@ export class Viewer {
         // The verbosity of console logging
         this.logLevel = options.logLevel || LogLevel.None;
 
-        // Level of spherical harmonics to utilize in rendering splats (assuming the data is present in the splat scene).
+        // Degree of spherical harmonics to utilize in rendering splats (assuming the data is present in the splat scene).
         // Valid values are 0 - 3. Default value is 0.
         this.sphericalHarmonicsDegree = options.sphericalHarmonicsDegree || 0;
 
@@ -977,8 +977,7 @@ export class Viewer {
             return KSplatLoader.loadFromURL(path, onProgress, streamBuiltSections, onSectionBuilt);
         } else if (format === SceneFormat.Ply) {
             return PlyLoader.loadFromURL(path, onProgress, streamBuiltSections, onSectionBuilt,
-                                         splatAlphaRemovalThreshold, 0, undefined, undefined,
-                                         undefined, undefined, this.sphericalHarmonicsDegree);
+                                         splatAlphaRemovalThreshold, 0, this.sphericalHarmonicsDegree);
         }
         return AbortablePromise.reject(new Error(`Viewer::downloadSplatSceneToSplatBuffer -> File format not supported: ${path}`));
     }

--- a/src/Viewer.js
+++ b/src/Viewer.js
@@ -141,6 +141,10 @@ export class Viewer {
         // The verbosity of console logging
         this.logLevel = options.logLevel || LogLevel.None;
 
+        // Level of spherical harmonics to utilize in rendering splats (assuming the data is present in the splat scene).
+        // Valid values are 0 - 3. Default value is 0.
+        this.sphericalHarmonicsDegree = options.sphericalHarmonicsDegree || 0;
+
         this.createSplatMesh();
 
         this.controls = null;
@@ -216,7 +220,7 @@ export class Viewer {
     createSplatMesh() {
         this.splatMesh = new SplatMesh(this.dynamicScene, this.halfPrecisionCovariancesOnGPU, this.devicePixelRatio,
                                        this.gpuAcceleratedSort, this.integerBasedSort, this.antialiased,
-                                       this.maxScreenSpaceSplatSize, this.logLevel);
+                                       this.maxScreenSpaceSplatSize, this.logLevel, this.sphericalHarmonicsDegree);
         this.splatMesh.frustumCulled = false;
     }
 
@@ -969,7 +973,8 @@ export class Viewer {
         } else if (format === SceneFormat.KSplat) {
             return KSplatLoader.loadFromURL(path, onProgress, streamBuiltSections, onSectionBuilt);
         } else if (format === SceneFormat.Ply) {
-            return PlyLoader.loadFromURL(path, onProgress, streamBuiltSections, onSectionBuilt, splatAlphaRemovalThreshold, 0);
+            return PlyLoader.loadFromURL(path, onProgress, streamBuiltSections, onSectionBuilt,
+                                         splatAlphaRemovalThreshold, 0, this.sphericalHarmonicsDegree);
         }
         return AbortablePromise.reject(new Error(`Viewer::downloadSplatSceneToSplatBuffer -> File format not supported: ${path}`));
     }

--- a/src/loaders/SplatBuffer.js
+++ b/src/loaders/SplatBuffer.js
@@ -334,6 +334,7 @@ export class SplatBuffer {
         }
         const tempVector = new THREE.Vector3();
         const tempMatrix3 = new THREE.Matrix3();
+        const thf = THREE.DataUtils.toHalfFloat.bind(THREE.DataUtils);
 
         return function(outSphericalHarmonicsArray, transform, srcFrom, srcTo, destFrom) {
             const splatCount = this.splatCount;
@@ -361,36 +362,45 @@ export class SplatBuffer {
 
                 if (this.sphericalHarmonicsDegree >= 1) {
                     const sectionFloatArray = this.compressionLevel === 1 ? section.dataArrayUint16 : section.dataArrayFloat32;
-                    outSphericalHarmonicsArray[shDestBase] = -this.fbf(sectionFloatArray[sphericalHarmonicsSrcBase + 2]);
-                    outSphericalHarmonicsArray[shDestBase + 1] = -this.fbf(sectionFloatArray[sphericalHarmonicsSrcBase]);
-                    outSphericalHarmonicsArray[shDestBase + 2] = this.fbf(sectionFloatArray[sphericalHarmonicsSrcBase + 1]);
+                    const s1 = -this.fbf(sectionFloatArray[sphericalHarmonicsSrcBase + 2]);
+                    const s2 = -this.fbf(sectionFloatArray[sphericalHarmonicsSrcBase]);
+                    const s3 = this.fbf(sectionFloatArray[sphericalHarmonicsSrcBase + 1]);
 
-                    outSphericalHarmonicsArray[shDestBase + 3] = -this.fbf(sectionFloatArray[sphericalHarmonicsSrcBase + 5]);
-                    outSphericalHarmonicsArray[shDestBase + 4] = -this.fbf(sectionFloatArray[sphericalHarmonicsSrcBase + 3]);
-                    outSphericalHarmonicsArray[shDestBase + 5] = this.fbf(sectionFloatArray[sphericalHarmonicsSrcBase + 4]);
+                    const s4 = -this.fbf(sectionFloatArray[sphericalHarmonicsSrcBase + 5]);
+                    const s5 = -this.fbf(sectionFloatArray[sphericalHarmonicsSrcBase + 3]);
+                    const s6 = this.fbf(sectionFloatArray[sphericalHarmonicsSrcBase + 4]);
 
-                    outSphericalHarmonicsArray[shDestBase + 6] = -this.fbf(sectionFloatArray[sphericalHarmonicsSrcBase + 8]);
-                    outSphericalHarmonicsArray[shDestBase + 7] = -this.fbf(sectionFloatArray[sphericalHarmonicsSrcBase + 6]);
-                    outSphericalHarmonicsArray[shDestBase + 8] = this.fbf(sectionFloatArray[sphericalHarmonicsSrcBase + 7]);
+                    const s7 = -this.fbf(sectionFloatArray[sphericalHarmonicsSrcBase + 8]);
+                    const s8 = -this.fbf(sectionFloatArray[sphericalHarmonicsSrcBase + 6]);
+                    const s9 = this.fbf(sectionFloatArray[sphericalHarmonicsSrcBase + 7]);
 
                     if (transform) {
-                        tempVector.set(outSphericalHarmonicsArray[shDestBase], outSphericalHarmonicsArray[shDestBase + 1],
-                                       outSphericalHarmonicsArray[shDestBase + 2]).applyMatrix3(tempMatrix3);
-                        outSphericalHarmonicsArray[shDestBase] = tempVector.x;
-                        outSphericalHarmonicsArray[shDestBase + 1] = tempVector.y;
-                        outSphericalHarmonicsArray[shDestBase + 2] = tempVector.z;
+                        tempVector.set(s1, s2, s3).applyMatrix3(tempMatrix3);
+                        outSphericalHarmonicsArray[shDestBase] = thf(tempVector.x);
+                        outSphericalHarmonicsArray[shDestBase + 1] = thf(tempVector.y);
+                        outSphericalHarmonicsArray[shDestBase + 2] = thf(tempVector.z);
 
-                        tempVector.set(outSphericalHarmonicsArray[shDestBase + 3], outSphericalHarmonicsArray[shDestBase + 4],
-                                       outSphericalHarmonicsArray[shDestBase + 5]).applyMatrix3(tempMatrix3);
-                        outSphericalHarmonicsArray[shDestBase + 3] = tempVector.x;
-                        outSphericalHarmonicsArray[shDestBase + 4] = tempVector.y;
-                        outSphericalHarmonicsArray[shDestBase + 5] = tempVector.z;
+                        tempVector.set(s4, s5, s6).applyMatrix3(tempMatrix3);
+                        outSphericalHarmonicsArray[shDestBase + 3] = thf(tempVector.x);
+                        outSphericalHarmonicsArray[shDestBase + 4] = thf(tempVector.y);
+                        outSphericalHarmonicsArray[shDestBase + 5] = thf(tempVector.z);
 
-                        tempVector.set(outSphericalHarmonicsArray[shDestBase + 6], outSphericalHarmonicsArray[shDestBase + 7],
-                                       outSphericalHarmonicsArray[shDestBase + 8]).applyMatrix3(tempMatrix3);
-                        outSphericalHarmonicsArray[shDestBase + 6] = tempVector.x;
-                        outSphericalHarmonicsArray[shDestBase + 7] = tempVector.y;
-                        outSphericalHarmonicsArray[shDestBase + 8] = tempVector.z;
+                        tempVector.set(s7, s8, s9).applyMatrix3(tempMatrix3);
+                        outSphericalHarmonicsArray[shDestBase + 6] = thf(tempVector.x);
+                        outSphericalHarmonicsArray[shDestBase + 7] = thf(tempVector.y);
+                        outSphericalHarmonicsArray[shDestBase + 8] = thf(tempVector.z);
+                    } else {
+                        outSphericalHarmonicsArray[shDestBase] = thf(s1);
+                        outSphericalHarmonicsArray[shDestBase + 1] = thf(s2);
+                        outSphericalHarmonicsArray[shDestBase + 2] = thf(s3);
+    
+                        outSphericalHarmonicsArray[shDestBase + 3] = thf(s4);
+                        outSphericalHarmonicsArray[shDestBase + 4] = thf(s5);
+                        outSphericalHarmonicsArray[shDestBase + 5] = thf(s6);
+    
+                        outSphericalHarmonicsArray[shDestBase + 6] = thf(s7);
+                        outSphericalHarmonicsArray[shDestBase + 7] = thf(s8);
+                        outSphericalHarmonicsArray[shDestBase + 8] = thf(s9);
                     }
                 }
 

--- a/src/loaders/SplatBuffer.js
+++ b/src/loaders/SplatBuffer.js
@@ -362,7 +362,7 @@ export class SplatBuffer {
 
                 if (this.sphericalHarmonicsDegree >= 1) {
                     const sectionFloatArray = this.compressionLevel === 1 ? section.dataArrayUint16 : section.dataArrayFloat32;
-                    const s1 = -this.fbf(sectionFloatArray[sphericalHarmonicsSrcBase + 2]);
+                   /* const s1 = -this.fbf(sectionFloatArray[sphericalHarmonicsSrcBase + 2]);
                     const s2 = -this.fbf(sectionFloatArray[sphericalHarmonicsSrcBase]);
                     const s3 = this.fbf(sectionFloatArray[sphericalHarmonicsSrcBase + 1]);
 
@@ -372,7 +372,19 @@ export class SplatBuffer {
 
                     const s7 = -this.fbf(sectionFloatArray[sphericalHarmonicsSrcBase + 8]);
                     const s8 = -this.fbf(sectionFloatArray[sphericalHarmonicsSrcBase + 6]);
-                    const s9 = this.fbf(sectionFloatArray[sphericalHarmonicsSrcBase + 7]);
+                    const s9 = this.fbf(sectionFloatArray[sphericalHarmonicsSrcBase + 7]);*/
+
+                    const s1 = this.fbf(sectionFloatArray[sphericalHarmonicsSrcBase]);
+                    const s2 = this.fbf(sectionFloatArray[sphericalHarmonicsSrcBase + 1]);
+                    const s3 = this.fbf(sectionFloatArray[sphericalHarmonicsSrcBase + 2]);
+
+                    const s4 = this.fbf(sectionFloatArray[sphericalHarmonicsSrcBase + 3]);
+                    const s5 = this.fbf(sectionFloatArray[sphericalHarmonicsSrcBase + 4]);
+                    const s6 = this.fbf(sectionFloatArray[sphericalHarmonicsSrcBase + 5]);
+
+                    const s7 = this.fbf(sectionFloatArray[sphericalHarmonicsSrcBase + 6]);
+                    const s8 = this.fbf(sectionFloatArray[sphericalHarmonicsSrcBase + 7]);
+                    const s9 = this.fbf(sectionFloatArray[sphericalHarmonicsSrcBase + 8]);
 
                     if (transform) {
                         tempVector.set(s1, s2, s3).applyMatrix3(tempMatrix3);

--- a/src/loaders/SplatBuffer.js
+++ b/src/loaders/SplatBuffer.js
@@ -433,11 +433,11 @@ export class SplatBuffer {
             addInto3(v5[0] * t4, v5[1] * t4, v5[2] * t4, outArray);
         };
 
-        const kSqrt01_04 = Math.sqrt(1.0 /  4.0);
-        const kSqrt03_04 = Math.sqrt(3.0 /  4.0);
-        const kSqrt01_03 = Math.sqrt(1.0 /  3.0);
-        const kSqrt04_03 = Math.sqrt(4.0 /  3.0);
-        const kSqrt01_12 = Math.sqrt(1.0 / 12.0);
+        const kSqrt0104 = Math.sqrt(1.0 / 4.0);
+        const kSqrt0304 = Math.sqrt(3.0 / 4.0);
+        const kSqrt0103 = Math.sqrt(1.0 / 3.0);
+        const kSqrt0403 = Math.sqrt(4.0 / 3.0);
+        const kSqrt0112 = Math.sqrt(1.0 / 12.0);
 
         return function(outSphericalHarmonicsArray, outSphericalHarmonicsDegree, transform,
                         srcFrom, srcTo, destFrom, desiredOutputCompressionLevel) {
@@ -498,7 +498,7 @@ export class SplatBuffer {
                     } else {
                         copy3(shIn1, shOut1);
                         copy3(shIn2, shOut2);
-                        copy3(shIn3, shOut3); 
+                        copy3(shIn3, shOut3);
                     }
 
                     let conversionFunc = noop;
@@ -555,39 +555,41 @@ export class SplatBuffer {
 
                             srcCompressionLevel = 0;
 
-                            sh21[0] = kSqrt01_04 * ((sh13[2] * sh11[0] + sh13[0] * sh11[2]) + (sh11[2] * sh13[0] + sh11[0] * sh13[2]));
+                            sh21[0] = kSqrt0104 * ((sh13[2] * sh11[0] + sh13[0] * sh11[2]) + (sh11[2] * sh13[0] + sh11[0] * sh13[2]));
                             sh21[1] = (sh13[1] * sh11[0] + sh11[1] * sh13[0]);
-                            sh21[2] = kSqrt03_04 * (sh13[1] * sh11[1] + sh11[1] * sh13[1]);
+                            sh21[2] = kSqrt0304 * (sh13[1] * sh11[1] + sh11[1] * sh13[1]);
                             sh21[3] = (sh13[1] * sh11[2] + sh11[1] * sh13[2]);
-                            sh21[4] = kSqrt01_04 * ((sh13[2] * sh11[2] - sh13[0] * sh11[0]) + (sh11[2] * sh13[2] - sh11[0] * sh13[0]));
+                            sh21[4] = kSqrt0104 * ((sh13[2] * sh11[2] - sh13[0] * sh11[0]) + (sh11[2] * sh13[2] - sh11[0] * sh13[0]));
                             dot5(shIn1, shIn2, shIn3, shIn4, shIn5, sh21, shOut1);
-                        
-                            sh22[0] = kSqrt01_04 * ((sh12[2] * sh11[0] + sh12[0] * sh11[2]) + (sh11[2] * sh12[0] + sh11[0] * sh12[2]));
+
+                            sh22[0] = kSqrt0104 * ((sh12[2] * sh11[0] + sh12[0] * sh11[2]) + (sh11[2] * sh12[0] + sh11[0] * sh12[2]));
                             sh22[1] = sh12[1] * sh11[0] + sh11[1] * sh12[0];
-                            sh22[2] = kSqrt03_04 * (sh12[1] * sh11[1] + sh11[1] * sh12[1]);
+                            sh22[2] = kSqrt0304 * (sh12[1] * sh11[1] + sh11[1] * sh12[1]);
                             sh22[3] = sh12[1] * sh11[2] + sh11[1] * sh12[2];
-                            sh22[4] = kSqrt01_04 * ((sh12[2] * sh11[2] - sh12[0] * sh11[0]) + (sh11[2] * sh12[2] - sh11[0] * sh12[0]));
+                            sh22[4] = kSqrt0104 * ((sh12[2] * sh11[2] - sh12[0] * sh11[0]) + (sh11[2] * sh12[2] - sh11[0] * sh12[0]));
                             dot5(shIn1, shIn2, shIn3, shIn4, shIn5, sh22, shOut2);
 
-                            sh23[0] = kSqrt01_03 * (sh12[2] * sh12[0] + sh12[0] * sh12[2]) + -kSqrt01_12 * ((sh13[2] * sh13[0] + sh13[0] * sh13[2]) + (sh11[2] * sh11[0] + sh11[0] * sh11[2]));
-                            sh23[1] = kSqrt04_03 * sh12[1] * sh12[0] + -kSqrt01_03 * (sh13[1] * sh13[0] + sh11[1] * sh11[0]);
-                            sh23[2] = sh12[1] * sh12[1] + -kSqrt01_04 * (sh13[1] * sh13[1] + sh11[1] * sh11[1]);
-                            sh23[3] = kSqrt04_03 * sh12[1] * sh12[2] + -kSqrt01_03 * (sh13[1] * sh13[2] + sh11[1] * sh11[2]);
-                            sh23[4] = kSqrt01_03 * (sh12[2] * sh12[2] - sh12[0] * sh12[0]) + -kSqrt01_12 * ((sh13[2] * sh13[2] - sh13[0] * sh13[0]) + (sh11[2] * sh11[2] - sh11[0] * sh11[0]));
+                            sh23[0] = kSqrt0103 * (sh12[2] * sh12[0] + sh12[0] * sh12[2]) + -kSqrt0112 *
+                                      ((sh13[2] * sh13[0] + sh13[0] * sh13[2]) + (sh11[2] * sh11[0] + sh11[0] * sh11[2]));
+                            sh23[1] = kSqrt0403 * sh12[1] * sh12[0] + -kSqrt0103 * (sh13[1] * sh13[0] + sh11[1] * sh11[0]);
+                            sh23[2] = sh12[1] * sh12[1] + -kSqrt0104 * (sh13[1] * sh13[1] + sh11[1] * sh11[1]);
+                            sh23[3] = kSqrt0403 * sh12[1] * sh12[2] + -kSqrt0103 * (sh13[1] * sh13[2] + sh11[1] * sh11[2]);
+                            sh23[4] = kSqrt0103 * (sh12[2] * sh12[2] - sh12[0] * sh12[0]) + -kSqrt0112 *
+                                      ((sh13[2] * sh13[2] - sh13[0] * sh13[0]) + (sh11[2] * sh11[2] - sh11[0] * sh11[0]));
                             dot5(shIn1, shIn2, shIn3, shIn4, shIn5, sh23, shOut3);
 
-                            sh24[0] = kSqrt01_04 * ((sh12[2] * sh13[0] + sh12[0] * sh13[2]) + (sh13[2] * sh12[0] + sh13[0] * sh12[2]));
+                            sh24[0] = kSqrt0104 * ((sh12[2] * sh13[0] + sh12[0] * sh13[2]) + (sh13[2] * sh12[0] + sh13[0] * sh12[2]));
                             sh24[1] = sh12[1] * sh13[0] + sh13[1] * sh12[0];
-                            sh24[2] = kSqrt03_04 * (sh12[1] * sh13[1] + sh13[1] * sh12[1]);
+                            sh24[2] = kSqrt0304 * (sh12[1] * sh13[1] + sh13[1] * sh12[1]);
                             sh24[3] = sh12[1] * sh13[2] + sh13[1] * sh12[2];
-                            sh24[4] = kSqrt01_04 * ((sh12[2] * sh13[2] - sh12[0] * sh13[0]) + (sh13[2] * sh12[2] - sh13[0] * sh12[0]));
+                            sh24[4] = kSqrt0104 * ((sh12[2] * sh13[2] - sh12[0] * sh13[0]) + (sh13[2] * sh12[2] - sh13[0] * sh12[0]));
                             dot5(shIn1, shIn2, shIn3, shIn4, shIn5, sh24, shOut4);
 
-                            sh25[0] = kSqrt01_04 * ((sh13[2] * sh13[0] + sh13[0] * sh13[2]) - (sh11[2] * sh11[0] + sh11[0] * sh11[2]));
+                            sh25[0] = kSqrt0104 * ((sh13[2] * sh13[0] + sh13[0] * sh13[2]) - (sh11[2] * sh11[0] + sh11[0] * sh11[2]));
                             sh25[1] = (sh13[1] * sh13[0] - sh11[1] * sh11[0]);
-                            sh25[2] = kSqrt03_04 * (sh13[1] * sh13[1] - sh11[1] * sh11[1]);
+                            sh25[2] = kSqrt0304 * (sh13[1] * sh13[1] - sh11[1] * sh11[1]);
                             sh25[3] = (sh13[1] * sh13[2] - sh11[1] * sh11[2]);
-                            sh25[4] = kSqrt01_04 * ((sh13[2] * sh13[2] - sh13[0] * sh13[0]) - (sh11[2] * sh11[2] - sh11[0] * sh11[0]));
+                            sh25[4] = kSqrt0104 * ((sh13[2] * sh13[2] - sh13[0] * sh13[0]) - (sh11[2] * sh11[2] - sh11[0] * sh11[0]));
                             dot5(shIn1, shIn2, shIn3, shIn4, shIn5, sh25, shOut5);
                         } else {
                             copy3(shIn1, shOut1);

--- a/src/loaders/SplatBuffer.js
+++ b/src/loaders/SplatBuffer.js
@@ -228,6 +228,9 @@ export class SplatBuffer {
                 rotationMatrix.makeRotationFromQuaternion(rotation);
                 tempMatrix.copy(scaleMatrix).multiply(rotationMatrix).multiply(transform);
                 tempMatrix.decompose(tempPosition, outRotation, outScale);
+            } else {
+                outScale.copy(scale);
+                outRotation.copy(rotation);
             }
         };
 

--- a/src/loaders/SplatBuffer.js
+++ b/src/loaders/SplatBuffer.js
@@ -77,7 +77,7 @@ export class SplatBuffer {
         this.constructFromBuffer(bufferData, secLoadedCountsToMax);
     }
 
-    fbf(f) {
+    toUncompressedFloat(f) {
         if (this.compressionLevel === 0) {
             return f;
         } else {
@@ -85,28 +85,17 @@ export class SplatBuffer {
         }
     };
 
-    fbfV3(v, o) {
+    toUncompressedFloatArray3(src, dest) {
         if (this.compressionLevel === 1) {
-            o.x = this.fbf(v.x);
-            o.y = this.fbf(v.y);
-            o.z = this.fbf(v.z);
+            dest[0] = this.toUncompressedFloat(src[0]);
+            dest[1] = this.toUncompressedFloat(src[1]);
+            dest[2] = this.toUncompressedFloat(src[2]);
         } else {
-            o.copy(v);
+            dest[0] = v[0];
+            dest[1] = v[1];
+            dest[2] = v[2];
         }
-        return o;
-    };
-
-    fbfA3(v, o) {
-        if (this.compressionLevel === 1) {
-            o[0] = this.fbf(v[0]);
-            o[1] = this.fbf(v[1]);
-            o[2] = this.fbf(v[2]);
-        } else {
-            o[0] = v[0];
-            o[1] = v[1];
-            o[2] = v[2];
-        }
-        return o;
+        return dest;
     };
 
     getSplatCount() {
@@ -179,15 +168,15 @@ export class SplatBuffer {
             const splatFloatBase = floatsPerSplat * localSplatIndex;
 
             const scaleBase = splatFloatBase + SplatBuffer.SplatScaleOffsetFloat;
-            outScale.set(this.fbf(sectionFloatArray[scaleBase]),
-                         this.fbf(sectionFloatArray[scaleBase + 1]),
-                         this.fbf(sectionFloatArray[scaleBase + 2]));
+            outScale.set(this.toUncompressedFloat(sectionFloatArray[scaleBase]),
+                         this.toUncompressedFloat(sectionFloatArray[scaleBase + 1]),
+                         this.toUncompressedFloat(sectionFloatArray[scaleBase + 2]));
 
             const rotationBase = splatFloatBase + SplatBuffer.SplatRotationOffsetFloat;
-            outRotation.set(this.fbf(sectionFloatArray[rotationBase + 1]),
-                            this.fbf(sectionFloatArray[rotationBase + 2]),
-                            this.fbf(sectionFloatArray[rotationBase + 3]),
-                            this.fbf(sectionFloatArray[rotationBase]));
+            outRotation.set(this.toUncompressedFloat(sectionFloatArray[rotationBase + 1]),
+                            this.toUncompressedFloat(sectionFloatArray[rotationBase + 2]),
+                            this.toUncompressedFloat(sectionFloatArray[rotationBase + 3]),
+                            this.toUncompressedFloat(sectionFloatArray[rotationBase]));
 
             if (transform) {
                 scaleMatrix.makeScale(outScale.x, outScale.y, outScale.z);
@@ -254,7 +243,7 @@ export class SplatBuffer {
         const transformedCovariance = new THREE.Matrix3();
         const transform3x3 = new THREE.Matrix3();
         const transform3x3Transpose = new THREE.Matrix3();
-        const thf = THREE.DataUtils.toHalfFloat.bind(THREE.DataUtils);
+        const toHalfFloat = THREE.DataUtils.toHalfFloat.bind(THREE.DataUtils);
 
         return function(scale, rotation, transform, outCovariance, outOffset = 0, desiredOutputCompressionLevel) {
 
@@ -275,12 +264,12 @@ export class SplatBuffer {
             }
 
             if (desiredOutputCompressionLevel === 1) {
-                outCovariance[outOffset] = thf(transformedCovariance.elements[0]);
-                outCovariance[outOffset + 1] = thf(transformedCovariance.elements[3]);
-                outCovariance[outOffset + 2] = thf(transformedCovariance.elements[6]);
-                outCovariance[outOffset + 3] = thf(transformedCovariance.elements[4]);
-                outCovariance[outOffset + 4] = thf(transformedCovariance.elements[7]);
-                outCovariance[outOffset + 5] = thf(transformedCovariance.elements[8]);
+                outCovariance[outOffset] = toHalfFloat(transformedCovariance.elements[0]);
+                outCovariance[outOffset + 1] = toHalfFloat(transformedCovariance.elements[3]);
+                outCovariance[outOffset + 2] = toHalfFloat(transformedCovariance.elements[6]);
+                outCovariance[outOffset + 3] = toHalfFloat(transformedCovariance.elements[4]);
+                outCovariance[outOffset + 4] = toHalfFloat(transformedCovariance.elements[7]);
+                outCovariance[outOffset + 5] = toHalfFloat(transformedCovariance.elements[8]);
             } else {
                 outCovariance[outOffset] = transformedCovariance.elements[0];
                 outCovariance[outOffset + 1] = transformedCovariance.elements[3];
@@ -315,15 +304,15 @@ export class SplatBuffer {
             const covarianceDestBase = (i - srcFrom + destFrom) * SplatBuffer.CovarianceComponentCount;
 
             const scaleBase = splatFloatBase + SplatBuffer.SplatScaleOffsetFloat;
-            scale.set(this.fbf(sectionFloatArray[scaleBase]),
-                      this.fbf(sectionFloatArray[scaleBase + 1]),
-                      this.fbf(sectionFloatArray[scaleBase + 2]));
+            scale.set(this.toUncompressedFloat(sectionFloatArray[scaleBase]),
+                      this.toUncompressedFloat(sectionFloatArray[scaleBase + 1]),
+                      this.toUncompressedFloat(sectionFloatArray[scaleBase + 2]));
 
             const rotationBase = splatFloatBase + SplatBuffer.SplatRotationOffsetFloat;
-            rotation.set(this.fbf(sectionFloatArray[rotationBase + 1]),
-                         this.fbf(sectionFloatArray[rotationBase + 2]),
-                         this.fbf(sectionFloatArray[rotationBase + 3]),
-                         this.fbf(sectionFloatArray[rotationBase]));
+            rotation.set(this.toUncompressedFloat(sectionFloatArray[rotationBase + 1]),
+                         this.toUncompressedFloat(sectionFloatArray[rotationBase + 2]),
+                         this.toUncompressedFloat(sectionFloatArray[rotationBase + 3]),
+                         this.toUncompressedFloat(sectionFloatArray[rotationBase]));
 
             SplatBuffer.computeCovariance(scale, rotation, transform, covarianceArray, covarianceDestBase, desiredOutputCompressionLevel);
         }
@@ -387,8 +376,8 @@ export class SplatBuffer {
         const shOut4 = [];
         const shOut5 = [];
 
-        const thf = THREE.DataUtils.toHalfFloat.bind(THREE.DataUtils);
-        const fbf = THREE.DataUtils.fromHalfFloat.bind(THREE.DataUtils);
+        const toHalfFloat = THREE.DataUtils.toHalfFloat.bind(THREE.DataUtils);
+        const fromHalfFloat = THREE.DataUtils.fromHalfFloat.bind(THREE.DataUtils);
         const noop = (v) => v;
 
         const set3 = (array, val1, val2, val3) => {
@@ -397,10 +386,22 @@ export class SplatBuffer {
             array[2] = val3;
         };
 
+        const set3FromArray = (array, srcArray, stride, srcBase) => {
+            array[0] = srcArray[srcBase];
+            array[1] = srcArray[srcBase + stride];
+            array[2] = srcArray[srcBase + stride + stride];
+        };
+
         const copy3 = (srcArray, destArray) => {
             destArray[0] = srcArray[0];
             destArray[1] = srcArray[1];
             destArray[2] = srcArray[2];
+        };
+
+        const setOutput3 = (srcArray, destArray, destBase, conversionFunc) => {
+            destArray[destBase] = conversionFunc(srcArray[0]);
+            destArray[destBase + 1] = conversionFunc(srcArray[1]);
+            destArray[destBase + 2] = conversionFunc(srcArray[2]);
         };
 
         return function(outSphericalHarmonicsArray, outSphericalHarmonicsDegree, transform,
@@ -432,28 +433,27 @@ export class SplatBuffer {
                 const sphericalHarmonicsSrcBase = floatsPerSplat * localSplatIndex + sphericalHarmonicsOffsetFloat;
                 const shDestBase = (i - srcFrom + destFrom) * outSphericalHarmonicsComponentsCount;
 
+                let compressionLevelForOutputConversion = transform ? 0 : this.compressionLevel;
+                let outputConversionFunc = noop;
+                if (compressionLevelForOutputConversion !== desiredOutputCompressionLevel) {
+                    if (compressionLevelForOutputConversion === 1) {
+                        if (desiredOutputCompressionLevel === 0) outputConversionFunc = fromHalfFloat;
+                    } else if (compressionLevelForOutputConversion === 0) {
+                        if (desiredOutputCompressionLevel === 1) outputConversionFunc = toHalfFloat;
+                    }
+                }
+
                 if (outSphericalHarmonicsDegree >= 1) {
                     const sectionFloatArray = this.compressionLevel === 1 ? section.dataArrayUint16 : section.dataArrayFloat32;
 
-                    let srcCompressionLevel = this.compressionLevel;
-
-                    set3(shIn1, sectionFloatArray[sphericalHarmonicsSrcBase],
-                                 sectionFloatArray[sphericalHarmonicsSrcBase + 3],
-                                 sectionFloatArray[sphericalHarmonicsSrcBase + 6]);
-
-                    set3(shIn2, sectionFloatArray[sphericalHarmonicsSrcBase + 1],
-                                 sectionFloatArray[sphericalHarmonicsSrcBase + 4],
-                                 sectionFloatArray[sphericalHarmonicsSrcBase + 7]);
-
-                    set3(shIn3, sectionFloatArray[sphericalHarmonicsSrcBase + 2],
-                                 sectionFloatArray[sphericalHarmonicsSrcBase + 5],
-                                 sectionFloatArray[sphericalHarmonicsSrcBase + 8]);
+                    set3FromArray(shIn1, sectionFloatArray, 3, sphericalHarmonicsSrcBase);
+                    set3FromArray(shIn2, sectionFloatArray, 3, sphericalHarmonicsSrcBase + 1);
+                    set3FromArray(shIn3, sectionFloatArray, 3, sphericalHarmonicsSrcBase + 2);
 
                     if (transform) {
-                        srcCompressionLevel = 0;
-                        this.fbfA3(shIn1, shIn1);
-                        this.fbfA3(shIn2, shIn2);
-                        this.fbfA3(shIn3, shIn3);
+                        this.toUncompressedFloatArray3(shIn1, shIn1);
+                        this.toUncompressedFloatArray3(shIn2, shIn2);
+                        this.toUncompressedFloatArray3(shIn3, shIn3);
                         SplatBuffer.rotateSphericalHarmonics3(shIn1, shIn2, shIn3, sh11, sh12, sh13, shOut1, shOut2, shOut3);
                     } else {
                         copy3(shIn1, shOut1);
@@ -461,58 +461,24 @@ export class SplatBuffer {
                         copy3(shIn3, shOut3);
                     }
 
-                    let conversionFunc = noop;
-                    if (srcCompressionLevel !== desiredOutputCompressionLevel) {
-                        if (srcCompressionLevel === 1) {
-                            if (desiredOutputCompressionLevel === 0) conversionFunc = fbf;
-                        } else if (srcCompressionLevel === 0) {
-                            if (desiredOutputCompressionLevel === 1) conversionFunc = thf;
-                        }
-                    }
-
-                    outSphericalHarmonicsArray[shDestBase] = conversionFunc(shOut1[0]);
-                    outSphericalHarmonicsArray[shDestBase + 1] = conversionFunc(shOut1[1]);
-                    outSphericalHarmonicsArray[shDestBase + 2] = conversionFunc(shOut1[2]);
-
-                    outSphericalHarmonicsArray[shDestBase + 3] = conversionFunc(shOut2[0]);
-                    outSphericalHarmonicsArray[shDestBase + 4] = conversionFunc(shOut2[1]);
-                    outSphericalHarmonicsArray[shDestBase + 5] = conversionFunc(shOut2[2]);
-
-                    outSphericalHarmonicsArray[shDestBase + 6] = conversionFunc(shOut3[0]);
-                    outSphericalHarmonicsArray[shDestBase + 7] = conversionFunc(shOut3[1]);
-                    outSphericalHarmonicsArray[shDestBase + 8] = conversionFunc(shOut3[2]);
+                    setOutput3(shOut1, outSphericalHarmonicsArray, shDestBase, outputConversionFunc);
+                    setOutput3(shOut2, outSphericalHarmonicsArray, shDestBase + 3, outputConversionFunc);
+                    setOutput3(shOut3, outSphericalHarmonicsArray, shDestBase + 6, outputConversionFunc);
 
                     if (outSphericalHarmonicsDegree >= 2) {
 
-                        srcCompressionLevel = this.compressionLevel;
-
-                        set3(shIn1, sectionFloatArray[sphericalHarmonicsSrcBase + 9],
-                                    sectionFloatArray[sphericalHarmonicsSrcBase + 14],
-                                    sectionFloatArray[sphericalHarmonicsSrcBase + 19]);
-
-                        set3(shIn2, sectionFloatArray[sphericalHarmonicsSrcBase + 10],
-                                    sectionFloatArray[sphericalHarmonicsSrcBase + 15],
-                                    sectionFloatArray[sphericalHarmonicsSrcBase + 20]);
-
-                        set3(shIn3, sectionFloatArray[sphericalHarmonicsSrcBase + 11],
-                                    sectionFloatArray[sphericalHarmonicsSrcBase + 16],
-                                    sectionFloatArray[sphericalHarmonicsSrcBase + 21]);
-
-                        set3(shIn4, sectionFloatArray[sphericalHarmonicsSrcBase + 12],
-                                    sectionFloatArray[sphericalHarmonicsSrcBase + 17],
-                                    sectionFloatArray[sphericalHarmonicsSrcBase + 22]);
-
-                        set3(shIn5, sectionFloatArray[sphericalHarmonicsSrcBase + 13],
-                                    sectionFloatArray[sphericalHarmonicsSrcBase + 18],
-                                    sectionFloatArray[sphericalHarmonicsSrcBase + 23]);
+                        set3FromArray(shIn1, sectionFloatArray, 5, sphericalHarmonicsSrcBase + 9);
+                        set3FromArray(shIn2, sectionFloatArray, 5, sphericalHarmonicsSrcBase + 10);
+                        set3FromArray(shIn3, sectionFloatArray, 5, sphericalHarmonicsSrcBase + 11);
+                        set3FromArray(shIn4, sectionFloatArray, 5, sphericalHarmonicsSrcBase + 12);
+                        set3FromArray(shIn5, sectionFloatArray, 5, sphericalHarmonicsSrcBase + 13);
 
                         if (transform) {
-                            srcCompressionLevel = 0;
-                            this.fbfA3(shIn1, shIn1);
-                            this.fbfA3(shIn2, shIn2);
-                            this.fbfA3(shIn3, shIn3);
-                            this.fbfA3(shIn4, shIn4);
-                            this.fbfA3(shIn5, shIn5);
+                            this.toUncompressedFloatArray3(shIn1, shIn1);
+                            this.toUncompressedFloatArray3(shIn2, shIn2);
+                            this.toUncompressedFloatArray3(shIn3, shIn3);
+                            this.toUncompressedFloatArray3(shIn4, shIn4);
+                            this.toUncompressedFloatArray3(shIn5, shIn5);
                             SplatBuffer.rotateSphericalHarmonics5(shIn1, shIn2, shIn3, shIn4, shIn5,
                                                                   sh11, sh12, sh13, sh21, sh22, sh23, sh24, sh25,
                                                                   shOut1, shOut2, shOut3, shOut4, shOut5);
@@ -524,35 +490,11 @@ export class SplatBuffer {
                             copy3(shIn5, shOut5);
                         }
 
-                        let conversionFunc = noop;
-                        if (srcCompressionLevel !== desiredOutputCompressionLevel) {
-                            if (srcCompressionLevel === 1) {
-                                if (desiredOutputCompressionLevel === 0) conversionFunc = fbf;
-                            } else if (srcCompressionLevel === 0) {
-                                if (desiredOutputCompressionLevel === 1) conversionFunc = thf;
-                            }
-                        }
-
-                        outSphericalHarmonicsArray[shDestBase + 9] = conversionFunc(shOut1[0]);
-                        outSphericalHarmonicsArray[shDestBase + 10] = conversionFunc(shOut1[1]);
-                        outSphericalHarmonicsArray[shDestBase + 11] = conversionFunc(shOut1[2]);
-
-                        outSphericalHarmonicsArray[shDestBase + 12] = conversionFunc(shOut2[0]);
-                        outSphericalHarmonicsArray[shDestBase + 13] = conversionFunc(shOut2[1]);
-                        outSphericalHarmonicsArray[shDestBase + 14] = conversionFunc(shOut2[2]);
-
-                        outSphericalHarmonicsArray[shDestBase + 15] = conversionFunc(shOut3[0]);
-                        outSphericalHarmonicsArray[shDestBase + 16] = conversionFunc(shOut3[1]);
-                        outSphericalHarmonicsArray[shDestBase + 17] = conversionFunc(shOut3[2]);
-
-                        outSphericalHarmonicsArray[shDestBase + 18] = conversionFunc(shOut4[0]);
-                        outSphericalHarmonicsArray[shDestBase + 19] = conversionFunc(shOut4[1]);
-                        outSphericalHarmonicsArray[shDestBase + 20] = conversionFunc(shOut4[2]);
-
-                        outSphericalHarmonicsArray[shDestBase + 21] = conversionFunc(shOut5[0]);
-                        outSphericalHarmonicsArray[shDestBase + 22] = conversionFunc(shOut5[1]);
-                        outSphericalHarmonicsArray[shDestBase + 23] = conversionFunc(shOut5[2]);
-
+                        setOutput3(shOut1, outSphericalHarmonicsArray, shDestBase + 9, outputConversionFunc);
+                        setOutput3(shOut2, outSphericalHarmonicsArray, shDestBase + 12, outputConversionFunc);
+                        setOutput3(shOut3, outSphericalHarmonicsArray, shDestBase + 15, outputConversionFunc);
+                        setOutput3(shOut4, outSphericalHarmonicsArray, shDestBase + 18, outputConversionFunc);
+                        setOutput3(shOut5, outSphericalHarmonicsArray, shDestBase + 21, outputConversionFunc);
                     }
                 }
             }
@@ -910,7 +852,7 @@ export class SplatBuffer {
         let totalSplatCount = 0;
 
         const tempRotation = new THREE.Quaternion();
-        const thf = THREE.DataUtils.toHalfFloat.bind(THREE.DataUtils);
+        const toHalfFloat = THREE.DataUtils.toHalfFloat.bind(THREE.DataUtils);
 
         for (let sa = 0; sa < splatArrays.length; sa ++) {
             const splatArray = splatArrays[sa];
@@ -992,32 +934,13 @@ export class SplatBuffer {
                            const sphericalHarmonics = new Float32Array(sectionBuffer, sphericalHarmonicsBase,
                                                                        sphericalHarmonicsComponentsPerSplat);
                            if (sphericalHarmonicsDegree >= 1) {
-                                sphericalHarmonics[0] = targetSplat[UncompressedSplatArray.OFFSET.FRC0];
-                                sphericalHarmonics[1] = targetSplat[UncompressedSplatArray.OFFSET.FRC1];
-                                sphericalHarmonics[2] = targetSplat[UncompressedSplatArray.OFFSET.FRC2];
-                                sphericalHarmonics[3] = targetSplat[UncompressedSplatArray.OFFSET.FRC3];
-                                sphericalHarmonics[4] = targetSplat[UncompressedSplatArray.OFFSET.FRC4];
-                                sphericalHarmonics[5] = targetSplat[UncompressedSplatArray.OFFSET.FRC5];
-                                sphericalHarmonics[6] = targetSplat[UncompressedSplatArray.OFFSET.FRC6];
-                                sphericalHarmonics[7] = targetSplat[UncompressedSplatArray.OFFSET.FRC7];
-                                sphericalHarmonics[8] = targetSplat[UncompressedSplatArray.OFFSET.FRC8];
-
+                                for (let s = 0; s < 9; s++) {
+                                    sphericalHarmonics[s] = targetSplat[UncompressedSplatArray.OFFSET.FRC0 + s];
+                                }
                                 if (sphericalHarmonicsDegree >= 2) {
-                                    sphericalHarmonics[9] = targetSplat[UncompressedSplatArray.OFFSET.FRC9];
-                                    sphericalHarmonics[10] = targetSplat[UncompressedSplatArray.OFFSET.FRC10];
-                                    sphericalHarmonics[11] = targetSplat[UncompressedSplatArray.OFFSET.FRC11];
-                                    sphericalHarmonics[12] = targetSplat[UncompressedSplatArray.OFFSET.FRC12];
-                                    sphericalHarmonics[13] = targetSplat[UncompressedSplatArray.OFFSET.FRC13];
-                                    sphericalHarmonics[14] = targetSplat[UncompressedSplatArray.OFFSET.FRC14];
-                                    sphericalHarmonics[15] = targetSplat[UncompressedSplatArray.OFFSET.FRC15];
-                                    sphericalHarmonics[16] = targetSplat[UncompressedSplatArray.OFFSET.FRC16];
-                                    sphericalHarmonics[17] = targetSplat[UncompressedSplatArray.OFFSET.FRC17];
-                                    sphericalHarmonics[18] = targetSplat[UncompressedSplatArray.OFFSET.FRC18];
-                                    sphericalHarmonics[19] = targetSplat[UncompressedSplatArray.OFFSET.FRC19];
-                                    sphericalHarmonics[20] = targetSplat[UncompressedSplatArray.OFFSET.FRC20];
-                                    sphericalHarmonics[21] = targetSplat[UncompressedSplatArray.OFFSET.FRC21];
-                                    sphericalHarmonics[22] = targetSplat[UncompressedSplatArray.OFFSET.FRC22];
-                                    sphericalHarmonics[23] = targetSplat[UncompressedSplatArray.OFFSET.FRC23];
+                                    for (let s = 0; s < 15; s++) {
+                                        sphericalHarmonics[s + 9] = targetSplat[UncompressedSplatArray.OFFSET.FRC9 + s];
+                                    }
                                 }
                            }
                         }
@@ -1032,13 +955,14 @@ export class SplatBuffer {
                                              targetSplat[UncompressedSplatArray.OFFSET.ROTATION2],
                                              targetSplat[UncompressedSplatArray.OFFSET.ROTATION3]);
                             tempRotation.normalize();
-                            rot.set([thf(tempRotation.x), thf(tempRotation.y), thf(tempRotation.z), thf(tempRotation.w)]);
-                            scale.set([thf(targetSplat[UncompressedSplatArray.OFFSET.SCALE0]),
-                                       thf(targetSplat[UncompressedSplatArray.OFFSET.SCALE1]),
-                                       thf(targetSplat[UncompressedSplatArray.OFFSET.SCALE2])]);
+                            rot.set([toHalfFloat(tempRotation.x), toHalfFloat(tempRotation.y),
+                                     toHalfFloat(tempRotation.z), toHalfFloat(tempRotation.w)]);
+                            scale.set([toHalfFloat(targetSplat[UncompressedSplatArray.OFFSET.SCALE0]),
+                                       toHalfFloat(targetSplat[UncompressedSplatArray.OFFSET.SCALE1]),
+                                       toHalfFloat(targetSplat[UncompressedSplatArray.OFFSET.SCALE2])]);
                         } else {
-                            rot.set([thf(1.), 0, 0, 0]);
-                            scale.set([thf(0.01), thf(0.01), thf(0.01)]);
+                            rot.set([toHalfFloat(1.), 0, 0, 0]);
+                            scale.set([toHalfFloat(0.01), toHalfFloat(0.01), toHalfFloat(0.01)]);
                         }
                         bucketCenterDelta.set(targetSplat[UncompressedSplatArray.OFFSET.X],
                                               targetSplat[UncompressedSplatArray.OFFSET.Y],
@@ -1054,32 +978,13 @@ export class SplatBuffer {
                             const sphericalHarmonics = new Uint16Array(sectionBuffer, sphericalHarmonicsBase,
                                                                        sphericalHarmonicsComponentsPerSplat);
                             if (sphericalHarmonicsDegree >= 1) {
-                                 sphericalHarmonics[0] = thf(targetSplat[UncompressedSplatArray.OFFSET.FRC0]);
-                                 sphericalHarmonics[1] = thf(targetSplat[UncompressedSplatArray.OFFSET.FRC1]);
-                                 sphericalHarmonics[2] = thf(targetSplat[UncompressedSplatArray.OFFSET.FRC2]);
-                                 sphericalHarmonics[3] = thf(targetSplat[UncompressedSplatArray.OFFSET.FRC3]);
-                                 sphericalHarmonics[4] = thf(targetSplat[UncompressedSplatArray.OFFSET.FRC4]);
-                                 sphericalHarmonics[5] = thf(targetSplat[UncompressedSplatArray.OFFSET.FRC5]);
-                                 sphericalHarmonics[6] = thf(targetSplat[UncompressedSplatArray.OFFSET.FRC6]);
-                                 sphericalHarmonics[7] = thf(targetSplat[UncompressedSplatArray.OFFSET.FRC7]);
-                                 sphericalHarmonics[8] = thf(targetSplat[UncompressedSplatArray.OFFSET.FRC8]);
-
-                                 if (sphericalHarmonicsDegree >= 2) {
-                                    sphericalHarmonics[9] = thf(targetSplat[UncompressedSplatArray.OFFSET.FRC9]);
-                                    sphericalHarmonics[10] = thf(targetSplat[UncompressedSplatArray.OFFSET.FRC10]);
-                                    sphericalHarmonics[11] = thf(targetSplat[UncompressedSplatArray.OFFSET.FRC11]);
-                                    sphericalHarmonics[12] = thf(targetSplat[UncompressedSplatArray.OFFSET.FRC12]);
-                                    sphericalHarmonics[13] = thf(targetSplat[UncompressedSplatArray.OFFSET.FRC13]);
-                                    sphericalHarmonics[14] = thf(targetSplat[UncompressedSplatArray.OFFSET.FRC14]);
-                                    sphericalHarmonics[15] = thf(targetSplat[UncompressedSplatArray.OFFSET.FRC15]);
-                                    sphericalHarmonics[16] = thf(targetSplat[UncompressedSplatArray.OFFSET.FRC16]);
-                                    sphericalHarmonics[17] = thf(targetSplat[UncompressedSplatArray.OFFSET.FRC17]);
-                                    sphericalHarmonics[18] = thf(targetSplat[UncompressedSplatArray.OFFSET.FRC18]);
-                                    sphericalHarmonics[19] = thf(targetSplat[UncompressedSplatArray.OFFSET.FRC19]);
-                                    sphericalHarmonics[20] = thf(targetSplat[UncompressedSplatArray.OFFSET.FRC20]);
-                                    sphericalHarmonics[21] = thf(targetSplat[UncompressedSplatArray.OFFSET.FRC21]);
-                                    sphericalHarmonics[22] = thf(targetSplat[UncompressedSplatArray.OFFSET.FRC22]);
-                                    sphericalHarmonics[23] = thf(targetSplat[UncompressedSplatArray.OFFSET.FRC23]);
+                                for (let s = 0; s < 9; s++) {
+                                    sphericalHarmonics[s] = toHalfFloat(targetSplat[UncompressedSplatArray.OFFSET.FRC0 + s]);
+                                }
+                                if (sphericalHarmonicsDegree >= 2) {
+                                    for (let s = 0; s < 15; s++) {
+                                        sphericalHarmonics[s + 9] = toHalfFloat(targetSplat[UncompressedSplatArray.OFFSET.FRC9 + s]);
+                                    }
                                 }
                             }
                          }

--- a/src/loaders/SplatBuffer.js
+++ b/src/loaders/SplatBuffer.js
@@ -34,6 +34,9 @@ export class SplatBuffer {
                 },
                 1: {
                     BytesPerSplat: 80,
+                },
+                2: {
+                    BytesPerSplat: 140,
                 }
             },
         },
@@ -51,6 +54,9 @@ export class SplatBuffer {
                 },
                 1: {
                     BytesPerSplat: 42,
+                },
+                2: {
+                    BytesPerSplat: 72,
                 }
             },
         }
@@ -342,7 +348,7 @@ export class SplatBuffer {
         const transformR3 = new THREE.Vector3();
         const thf = THREE.DataUtils.toHalfFloat.bind(THREE.DataUtils);
 
-        return function(outSphericalHarmonicsArray, transform, srcFrom, srcTo, destFrom) {
+        return function(outSphericalHarmonicsArray, outSphericalHarmonicsDegree, transform, srcFrom, srcTo, destFrom) {
             const splatCount = this.splatCount;
 
             srcFrom = srcFrom || 0;
@@ -357,6 +363,9 @@ export class SplatBuffer {
                 transformR3.set(tempMatrix3.elements[3], -tempMatrix3.elements[6], tempMatrix3.elements[0]);
             }
 
+            outSphericalHarmonicsDegree = Math.min(outSphericalHarmonicsDegree, this.sphericalHarmonicsDegree);
+            const outSphericalHarmonicsComponentsCount = getSphericalHarmonicsComponentCountForDegree(outSphericalHarmonicsDegree);
+
             for (let i = srcFrom; i <= srcTo; i++) {
 
                 const sectionIndex = this.globalSplatIndexToSectionMap[i];
@@ -365,9 +374,9 @@ export class SplatBuffer {
 
                 const sphericalHarmonicsOffsetFloat = SplatBuffer.CompressionLevels[this.compressionLevel].SphericalHarmonicsOffsetFloat;
                 const sphericalHarmonicsSrcBase = floatsPerSplat * localSplatIndex + sphericalHarmonicsOffsetFloat;
-                const shDestBase = (i - srcFrom + destFrom) * this.sphericalHarmonicsComponentsPerSplat;
+                const shDestBase = (i - srcFrom + destFrom) * outSphericalHarmonicsComponentsCount;
 
-                if (this.sphericalHarmonicsDegree >= 1) {
+                if (outSphericalHarmonicsDegree >= 1) {
                     const sectionFloatArray = this.compressionLevel === 1 ? section.dataArrayUint16 : section.dataArrayFloat32;
 
                     const s1 = this.fbf(sectionFloatArray[sphericalHarmonicsSrcBase]);
@@ -415,6 +424,48 @@ export class SplatBuffer {
                         outSphericalHarmonicsArray[shDestBase + 6] = thf(s7);
                         outSphericalHarmonicsArray[shDestBase + 7] = thf(s8);
                         outSphericalHarmonicsArray[shDestBase + 8] = thf(s9);
+                    }
+
+                    if (outSphericalHarmonicsDegree >= 2) {
+                        const s10 = this.fbf(sectionFloatArray[sphericalHarmonicsSrcBase + 9]);
+                        const s11 = this.fbf(sectionFloatArray[sphericalHarmonicsSrcBase + 14]);
+                        const s12 = this.fbf(sectionFloatArray[sphericalHarmonicsSrcBase + 19]);
+
+                        const s13 = this.fbf(sectionFloatArray[sphericalHarmonicsSrcBase + 10]);
+                        const s14 = this.fbf(sectionFloatArray[sphericalHarmonicsSrcBase + 15]);
+                        const s15 = this.fbf(sectionFloatArray[sphericalHarmonicsSrcBase + 20]);
+
+                        const s16 = this.fbf(sectionFloatArray[sphericalHarmonicsSrcBase + 11]);
+                        const s17 = this.fbf(sectionFloatArray[sphericalHarmonicsSrcBase + 16]);
+                        const s18 = this.fbf(sectionFloatArray[sphericalHarmonicsSrcBase + 21]);
+
+                        const s19 = this.fbf(sectionFloatArray[sphericalHarmonicsSrcBase + 12]);
+                        const s20 = this.fbf(sectionFloatArray[sphericalHarmonicsSrcBase + 17]);
+                        const s21 = this.fbf(sectionFloatArray[sphericalHarmonicsSrcBase + 22]);
+
+                        const s22 = this.fbf(sectionFloatArray[sphericalHarmonicsSrcBase + 13]);
+                        const s23 = this.fbf(sectionFloatArray[sphericalHarmonicsSrcBase + 18]);
+                        const s24 = this.fbf(sectionFloatArray[sphericalHarmonicsSrcBase + 23]);
+
+                        outSphericalHarmonicsArray[shDestBase + 9] = thf(s10);
+                        outSphericalHarmonicsArray[shDestBase + 10] = thf(s11);
+                        outSphericalHarmonicsArray[shDestBase + 11] = thf(s12);
+
+                        outSphericalHarmonicsArray[shDestBase + 12] = thf(s13);
+                        outSphericalHarmonicsArray[shDestBase + 13] = thf(s14);
+                        outSphericalHarmonicsArray[shDestBase + 14] = thf(s15);
+
+                        outSphericalHarmonicsArray[shDestBase + 15] = thf(s16);
+                        outSphericalHarmonicsArray[shDestBase + 16] = thf(s17);
+                        outSphericalHarmonicsArray[shDestBase + 17] = thf(s18);
+
+                        outSphericalHarmonicsArray[shDestBase + 18] = thf(s19);
+                        outSphericalHarmonicsArray[shDestBase + 19] = thf(s20);
+                        outSphericalHarmonicsArray[shDestBase + 20] = thf(s21);
+
+                        outSphericalHarmonicsArray[shDestBase + 21] = thf(s22);
+                        outSphericalHarmonicsArray[shDestBase + 22] = thf(s23);
+                        outSphericalHarmonicsArray[shDestBase + 23] = thf(s24);
                     }
                 }
             }
@@ -780,6 +831,24 @@ export class SplatBuffer {
                                 sphericalHarmonics[6] = targetSplat[UncompressedSplatArray.OFFSET.FRC6];
                                 sphericalHarmonics[7] = targetSplat[UncompressedSplatArray.OFFSET.FRC7];
                                 sphericalHarmonics[8] = targetSplat[UncompressedSplatArray.OFFSET.FRC8];
+
+                                if (sphericalHarmonicsDegree >= 2) {
+                                    sphericalHarmonics[9] = targetSplat[UncompressedSplatArray.OFFSET.FRC9];
+                                    sphericalHarmonics[10] = targetSplat[UncompressedSplatArray.OFFSET.FRC10];
+                                    sphericalHarmonics[11] = targetSplat[UncompressedSplatArray.OFFSET.FRC11];
+                                    sphericalHarmonics[12] = targetSplat[UncompressedSplatArray.OFFSET.FRC12];
+                                    sphericalHarmonics[13] = targetSplat[UncompressedSplatArray.OFFSET.FRC13];
+                                    sphericalHarmonics[14] = targetSplat[UncompressedSplatArray.OFFSET.FRC14];
+                                    sphericalHarmonics[15] = targetSplat[UncompressedSplatArray.OFFSET.FRC15];
+                                    sphericalHarmonics[16] = targetSplat[UncompressedSplatArray.OFFSET.FRC16];
+                                    sphericalHarmonics[17] = targetSplat[UncompressedSplatArray.OFFSET.FRC17];
+                                    sphericalHarmonics[18] = targetSplat[UncompressedSplatArray.OFFSET.FRC18];
+                                    sphericalHarmonics[19] = targetSplat[UncompressedSplatArray.OFFSET.FRC19];
+                                    sphericalHarmonics[20] = targetSplat[UncompressedSplatArray.OFFSET.FRC20];
+                                    sphericalHarmonics[21] = targetSplat[UncompressedSplatArray.OFFSET.FRC21];
+                                    sphericalHarmonics[22] = targetSplat[UncompressedSplatArray.OFFSET.FRC22];
+                                    sphericalHarmonics[23] = targetSplat[UncompressedSplatArray.OFFSET.FRC23];
+                                }
                            }
                         }
                     } else {
@@ -824,6 +893,24 @@ export class SplatBuffer {
                                  sphericalHarmonics[6] = thf(targetSplat[UncompressedSplatArray.OFFSET.FRC6]);
                                  sphericalHarmonics[7] = thf(targetSplat[UncompressedSplatArray.OFFSET.FRC7]);
                                  sphericalHarmonics[8] = thf(targetSplat[UncompressedSplatArray.OFFSET.FRC8]);
+
+                                 if (sphericalHarmonicsDegree >= 2) {
+                                    sphericalHarmonics[9] = thf(targetSplat[UncompressedSplatArray.OFFSET.FRC9]);
+                                    sphericalHarmonics[10] = thf(targetSplat[UncompressedSplatArray.OFFSET.FRC10]);
+                                    sphericalHarmonics[11] = thf(targetSplat[UncompressedSplatArray.OFFSET.FRC11]);
+                                    sphericalHarmonics[12] = thf(targetSplat[UncompressedSplatArray.OFFSET.FRC12]);
+                                    sphericalHarmonics[13] = thf(targetSplat[UncompressedSplatArray.OFFSET.FRC13]);
+                                    sphericalHarmonics[14] = thf(targetSplat[UncompressedSplatArray.OFFSET.FRC14]);
+                                    sphericalHarmonics[15] = thf(targetSplat[UncompressedSplatArray.OFFSET.FRC15]);
+                                    sphericalHarmonics[16] = thf(targetSplat[UncompressedSplatArray.OFFSET.FRC16]);
+                                    sphericalHarmonics[17] = thf(targetSplat[UncompressedSplatArray.OFFSET.FRC17]);
+                                    sphericalHarmonics[18] = thf(targetSplat[UncompressedSplatArray.OFFSET.FRC18]);
+                                    sphericalHarmonics[19] = thf(targetSplat[UncompressedSplatArray.OFFSET.FRC19]);
+                                    sphericalHarmonics[20] = thf(targetSplat[UncompressedSplatArray.OFFSET.FRC20]);
+                                    sphericalHarmonics[21] = thf(targetSplat[UncompressedSplatArray.OFFSET.FRC21]);
+                                    sphericalHarmonics[22] = thf(targetSplat[UncompressedSplatArray.OFFSET.FRC22]);
+                                    sphericalHarmonics[23] = thf(targetSplat[UncompressedSplatArray.OFFSET.FRC23]);
+                                }
                             }
                          }
                     }

--- a/src/loaders/SplatBuffer.js
+++ b/src/loaders/SplatBuffer.js
@@ -3,13 +3,17 @@ import { UncompressedSplatArray } from './UncompressedSplatArray.js';
 import { clamp, getSphericalHarmonicsComponentCountForDegree } from '../Util.js';
 
 const toHalfFloat = THREE.DataUtils.toHalfFloat.bind(THREE.DataUtils);
+
 const toUint8 = (v) => {
     return Math.floor(v * 128) + 128;
 };
+
 const fromUint8 = (v) => {
     return (v / 255) * 2.0 - 1.0;
 };
+
 const fromHalfFloat = THREE.DataUtils.fromHalfFloat.bind(THREE.DataUtils);
+
 const fromHalfFloatToUint8 = (v) => {
     return Math.floor(fromHalfFloat(v) * 128) + 128;
 };

--- a/src/loaders/SplatBuffer.js
+++ b/src/loaders/SplatBuffer.js
@@ -25,16 +25,24 @@ export class SplatBuffer {
             BytesPerColor: 4,
             BytesPerScale: 12,
             BytesPerRotation: 16,
-            BytesPerSplat: 44,
-            ScaleRange: 1
+            ScaleRange: 1,
+            SphericalHarmonicsLevels: {
+                0: {
+                    BytesPerSplat: 44,
+                }
+            },
         },
         1: {
             BytesPerCenter: 6,
             BytesPerColor: 4,
             BytesPerScale: 6,
             BytesPerRotation: 8,
-            BytesPerSplat: 24,
-            ScaleRange: 32767
+            ScaleRange: 32767,
+            SphericalHarmonicsLevels: {
+                0: {
+                    BytesPerSplat: 24,
+                }
+            },
         }
     };
 
@@ -324,6 +332,7 @@ export class SplatBuffer {
         const splatCount = headerArrayUint32[4];
         const compressionLevel = headerArrayUint16[10];
         const sceneCenter = new THREE.Vector3(headerArrayFloat32[6], headerArrayFloat32[7], headerArrayFloat32[8]);
+        const sphericalHarmonicsLevel = headerArrayUint16[18];
 
         return {
             versionMajor,
@@ -333,7 +342,8 @@ export class SplatBuffer {
             maxSplatCount,
             splatCount,
             compressionLevel,
-            sceneCenter
+            sceneCenter,
+            sphericalHarmonicsLevel
         };
     }
 

--- a/src/loaders/SplatBuffer.js
+++ b/src/loaders/SplatBuffer.js
@@ -377,7 +377,13 @@ export class SplatBuffer {
         const shOut5 = [];
 
         const toHalfFloat = THREE.DataUtils.toHalfFloat.bind(THREE.DataUtils);
+        const toUint8 = (v) => {
+            return Math.floor(v * 128) + 128;
+        };
         const fromHalfFloat = THREE.DataUtils.fromHalfFloat.bind(THREE.DataUtils);
+        const fromHalfFloatToUint8 = (v) => {
+            return Math.floor(fromHalfFloat(v) * 128) + 128;
+        };
         const noop = (v) => v;
 
         const set3 = (array, val1, val2, val3) => {
@@ -438,8 +444,10 @@ export class SplatBuffer {
                 if (compressionLevelForOutputConversion !== desiredOutputCompressionLevel) {
                     if (compressionLevelForOutputConversion === 1) {
                         if (desiredOutputCompressionLevel === 0) outputConversionFunc = fromHalfFloat;
+                        else if (desiredOutputCompressionLevel == 2) outputConversionFunc = fromHalfFloatToUint8;
                     } else if (compressionLevelForOutputConversion === 0) {
                         if (desiredOutputCompressionLevel === 1) outputConversionFunc = toHalfFloat;
+                        else if (desiredOutputCompressionLevel == 2) outputConversionFunc = toUint8;
                     }
                 }
 

--- a/src/loaders/SplatPartitioner.js
+++ b/src/loaders/SplatPartitioner.js
@@ -28,7 +28,7 @@ export class SplatPartitioner {
 
         const newArrays = [];
         for (let s = 0; s < sectionCount; s++) {
-            const sectionSplats = new UncompressedSplatArray();
+            const sectionSplats = new UncompressedSplatArray(splatArray.sphericalHarmonicsDegree);
             const sectionFilter = sectionFilters[s];
             for (let i = 0; i < splatArray.splatCount; i++) {
                 if (sectionFilter(i)) {

--- a/src/loaders/UncompressedSplatArray.js
+++ b/src/loaders/UncompressedSplatArray.js
@@ -1,3 +1,6 @@
+import { getSphericalHarmonicsComponentCountForDegree } from '../Util.js';
+
+const BASE_COMPONENT_COUNT = 14;
 
 export class UncompressedSplatArray {
 
@@ -15,16 +18,32 @@ export class UncompressedSplatArray {
         FDC0: 10,
         FDC1: 11,
         FDC2: 12,
-        OPACITY: 13
+        OPACITY: 13,
+        FRC0: 14,
+        FRC1: 15,
+        FRC2: 16,
+        FRC3: 17,
+        FRC4: 18,
+        FRC5: 19,
+        FRC6: 20,
+        FRC7: 21,
+        FRC8: 22,
     };
 
-    constructor() {
+    constructor(sphericalHarmonicsDegree = 0) {
+        this.sphericalHarmonicsDegree = sphericalHarmonicsDegree;
+        this.sphericalHarmonicsCount = getSphericalHarmonicsComponentCountForDegree(this.sphericalHarmonicsDegree);
+        this.componentCount = this.sphericalHarmonicsCount + BASE_COMPONENT_COUNT;
+        this.defaultSphericalHarmonics = new Array(this.sphericalHarmonicsCount).fill(0);
         this.splats = [];
         this.splatCount = 0;
     }
 
-    static createSplat() {
-        return [0, 0, 0, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0];
+    static createSplat(sphericalHarmonicsDegree = 0) {
+        const baseSplat = [0, 0, 0, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0];
+        let shEntries = getSphericalHarmonicsComponentCountForDegree(sphericalHarmonicsDegree);
+        for (let i = 0; i < shEntries; i++) baseSplat.push(0);
+        return baseSplat;
     }
 
     addSplat(splat) {
@@ -37,21 +56,26 @@ export class UncompressedSplatArray {
     }
 
     addDefaultSplat() {
-        const newSplat = UncompressedSplatArray.createSplat();
+        const newSplat = UncompressedSplatArray.createSplat(this.sphericalHarmonicsDegree);
         this.addSplat(newSplat);
         return newSplat;
     }
 
-    addSplatFromComonents(x, y, z, scale0, scale1, scale2, rot0, rot1, rot2, rot3, r, g, b, opacity) {
-        const newSplat = [x, y, z, scale0, scale1, scale2, rot0, rot1, rot2, rot3, r, g, b, opacity];
+    addSplatFromComonents(x, y, z, scale0, scale1, scale2, rot0, rot1, rot2, rot3, r, g, b, opacity, ...rest) {
+        const newSplat = [x, y, z, scale0, scale1, scale2, rot0, rot1, rot2, rot3, r, g, b, opacity, ...this.defaultSphericalHarmonics];
+        for (let i = 0; i < rest.length && i < this.sphericalHarmonicsCount; i++) {
+            newSplat[i] = rest[i];
+        }
         this.addSplat(newSplat);
         return newSplat;
     }
 
     addSplatFromArray(src, srcIndex) {
         const srcSplat = src.splats[srcIndex];
-        this.addSplatFromComonents(srcSplat[0], srcSplat[1], srcSplat[2], srcSplat[3], srcSplat[4], srcSplat[5],
-                                   srcSplat[6], srcSplat[7], srcSplat[8], srcSplat[9],
-                                   srcSplat[10], srcSplat[11], srcSplat[12], srcSplat[13]);
+        const newSplat = UncompressedSplatArray.createSplat(this.sphericalHarmonicsDegree);
+        for (let i = 0; i < this.componentCount && i < srcSplat.length; i++) {
+            newSplat[i] = srcSplat[i];
+        }
+        this.addSplat(newSplat);
     }
 }

--- a/src/loaders/UncompressedSplatArray.js
+++ b/src/loaders/UncompressedSplatArray.js
@@ -28,6 +28,21 @@ export class UncompressedSplatArray {
         FRC6: 20,
         FRC7: 21,
         FRC8: 22,
+        FRC9: 23,
+        FRC10: 24,
+        FRC11: 25,
+        FRC12: 26,
+        FRC13: 27,
+        FRC14: 28,
+        FRC15: 29,
+        FRC16: 30,
+        FRC17: 31,
+        FRC18: 32,
+        FRC19: 33,
+        FRC20: 34,
+        FRC21: 35,
+        FRC22: 36,
+        FRC23: 37,
     };
 
     constructor(sphericalHarmonicsDegree = 0) {

--- a/src/loaders/ksplat/KSplatLoader.js
+++ b/src/loaders/ksplat/KSplatLoader.js
@@ -145,7 +145,8 @@ export class KSplatLoader {
                             reachedSections++;
                             const bytesPastSSectionSplatDataStart = numBytesLoaded - bytesRequiredToReachSectionSplatData;
                             const baseDescriptor = SplatBuffer.CompressionLevels[header.compressionLevel];
-                            const bytesPerSplat = baseDescriptor.SphericalHarmonicsDegrees[header.sphericalHarmonicsDegree].BytesPerSplat;
+                            const shDesc = baseDescriptor.SphericalHarmonicsDegrees[sectionHeader.sphericalHarmonicsDegree];
+                            const bytesPerSplat = shDesc.BytesPerSplat;
                             let loadedSplatsForSection = Math.floor(bytesPastSSectionSplatDataStart / bytesPerSplat);
                             loadedSplatsForSection = Math.min(loadedSplatsForSection, sectionHeader.maxSplatCount);
                             loadedSplatCount += loadedSplatsForSection;

--- a/src/loaders/ksplat/KSplatLoader.js
+++ b/src/loaders/ksplat/KSplatLoader.js
@@ -145,7 +145,7 @@ export class KSplatLoader {
                             reachedSections++;
                             const bytesPastSSectionSplatDataStart = numBytesLoaded - bytesRequiredToReachSectionSplatData;
                             const baseDescriptor = SplatBuffer.CompressionLevels[header.compressionLevel];
-                            const bytesPerSplat = baseDescriptor.SphericalHarmonicsLevels[header.sphericalHarmonicsLevel].BytesPerSplat;
+                            const bytesPerSplat = baseDescriptor.SphericalHarmonicsDegrees[header.sphericalHarmonicsDegree].BytesPerSplat;
                             let loadedSplatsForSection = Math.floor(bytesPastSSectionSplatDataStart / bytesPerSplat);
                             loadedSplatsForSection = Math.min(loadedSplatsForSection, sectionHeader.maxSplatCount);
                             loadedSplatCount += loadedSplatsForSection;

--- a/src/loaders/ksplat/KSplatLoader.js
+++ b/src/loaders/ksplat/KSplatLoader.js
@@ -144,7 +144,8 @@ export class KSplatLoader {
                         if (numBytesLoaded >= bytesRequiredToReachSectionSplatData) {
                             reachedSections++;
                             const bytesPastSSectionSplatDataStart = numBytesLoaded - bytesRequiredToReachSectionSplatData;
-                            const bytesPerSplat = SplatBuffer.CompressionLevels[header.compressionLevel].BytesPerSplat;
+                            const baseDescriptor = SplatBuffer.CompressionLevels[header.compressionLevel];
+                            const bytesPerSplat = baseDescriptor.SphericalHarmonicsLevels[header.sphericalHarmonicsLevel].BytesPerSplat;
                             let loadedSplatsForSection = Math.floor(bytesPastSSectionSplatDataStart / bytesPerSplat);
                             loadedSplatsForSection = Math.min(loadedSplatsForSection, sectionHeader.maxSplatCount);
                             loadedSplatCount += loadedSplatsForSection;

--- a/src/loaders/ply/CompressedPlyParser.js
+++ b/src/loaders/ply/CompressedPlyParser.js
@@ -364,7 +364,7 @@ export class CompressedPlyParser {
     const outBytesPerCenter = SplatBuffer.CompressionLevels[0].BytesPerCenter;
     const outBytesPerScale = SplatBuffer.CompressionLevels[0].BytesPerScale;
     const outBytesPerRotation = SplatBuffer.CompressionLevels[0].BytesPerRotation;
-    const outBytesPerSplat = SplatBuffer.CompressionLevels[0].BytesPerSplat;
+    const outBytesPerSplat = SplatBuffer.CompressionLevels[0].SphericalHarmonicsLevels[0].BytesPerSplat;
 
     const { positionExtremes, scaleExtremes, position, rotation, scale, color } =
       CompressedPlyParser.getElementStorageArrays(chunkElement, vertexElement);

--- a/src/loaders/ply/CompressedPlyParser.js
+++ b/src/loaders/ply/CompressedPlyParser.js
@@ -364,7 +364,7 @@ export class CompressedPlyParser {
     const outBytesPerCenter = SplatBuffer.CompressionLevels[0].BytesPerCenter;
     const outBytesPerScale = SplatBuffer.CompressionLevels[0].BytesPerScale;
     const outBytesPerRotation = SplatBuffer.CompressionLevels[0].BytesPerRotation;
-    const outBytesPerSplat = SplatBuffer.CompressionLevels[0].SphericalHarmonicsLevels[0].BytesPerSplat;
+    const outBytesPerSplat = SplatBuffer.CompressionLevels[0].SphericalHarmonicsDegrees[0].BytesPerSplat;
 
     const { positionExtremes, scaleExtremes, position, rotation, scale, color } =
       CompressedPlyParser.getElementStorageArrays(chunkElement, vertexElement);

--- a/src/loaders/ply/PlyLoader.js
+++ b/src/loaders/ply/PlyLoader.js
@@ -86,7 +86,8 @@ export class PlyLoader {
                             readyToLoadSplatData = true;
                         }
 
-                        const splatBufferSizeBytes = splatDataOffsetBytes + SplatBuffer.CompressionLevels[0].BytesPerSplat * maxSplatCount;
+                        const shDescriptor = SplatBuffer.CompressionLevels[0].SphericalHarmonicsLevels[header.sphericalHarmonicsLevel];
+                        const splatBufferSizeBytes = splatDataOffsetBytes + shDescriptor.BytesPerSplat * maxSplatCount;
                         streamBufferOut = new ArrayBuffer(splatBufferSizeBytes);
                         SplatBuffer.writeHeaderToBuffer({
                             versionMajor: SplatBuffer.CurrentMajorVersion,
@@ -130,15 +131,16 @@ export class PlyLoader {
                             const parsedDataViewOffset = numBytesParsed - chunks[0].startBytes;
                             const dataToParse = new DataView(streamBufferIn, parsedDataViewOffset, numBytesToParse);
 
-                            const outOffset = splatCount * SplatBuffer.CompressionLevels[0].BytesPerSplat + splatDataOffsetBytes;
+                            const shDescriptor = SplatBuffer.CompressionLevels[0].SphericalHarmonicsLevels[header.sphericalHarmonicsLevel];
+                            const outOffset = splatCount * shDescriptor.BytesPerSplat + splatDataOffsetBytes;
 
                             if (compressed) {
                                 CompressedPlyParser.parseToUncompressedSplatBufferSection(header.chunkElement, header.vertexElement, 0,
                                                                                           addedSplatCount - 1, splatCount,
                                                                                           dataToParse, 0, streamBufferOut, outOffset);
                             } else {
-                                PlyParser.parseToUncompressedSplatBufferSection(header, 0, addedSplatCount - 1,
-                                                                                dataToParse, 0, streamBufferOut, outOffset);
+                                PlyParser.parseToUncompressedSplatBufferSection(header, 0, addedSplatCount - 1, dataToParse, 0, streamBufferOut,
+                                                                                outOffset, header.sphericalHarmonicsLevel);
                             }
 
                             splatCount = newSplatCount;

--- a/src/loaders/ply/PlyLoader.js
+++ b/src/loaders/ply/PlyLoader.js
@@ -98,7 +98,8 @@ export class PlyLoader {
                             maxSplatCount: maxSplatCount,
                             splatCount: splatCount,
                             compressionLevel: 0,
-                            sceneCenter: new THREE.Vector3()
+                            sceneCenter: new THREE.Vector3(),
+                            sphericalHarmonicsDegree: outSphericalHarmonicsDegree
                         }, streamBufferOut);
 
                         numBytesStreamed = header.headerSizeBytes;

--- a/src/loaders/ply/PlyLoader.js
+++ b/src/loaders/ply/PlyLoader.js
@@ -27,7 +27,7 @@ function storeChunksInBuffer(chunks, buffer) {
 export class PlyLoader {
 
     static loadFromURL(fileName, onProgress, streamLoadData, onStreamedSectionProgress, minimumAlpha, compressionLevel,
-                       sectionSize, sceneCenter, blockSize, bucketSize, outSphericalHarmonicsDegree = 0) {
+                       outSphericalHarmonicsDegree = 0, sectionSize, sceneCenter, blockSize, bucketSize) {
 
         const streamedSectionSizeBytes = Constants.StreamingSectionSize;
         const splatDataOffsetBytes = SplatBuffer.HeaderSizeBytes + SplatBuffer.SectionHeaderSizeBytes;
@@ -193,8 +193,8 @@ export class PlyLoader {
         return fetchWithProgress(fileName, localOnProgress, !streamLoadData).then((plyFileData) => {
             if (onProgress) onProgress(0, '0%', LoaderStatus.Processing);
             const loadPromise = streamLoadData ? streamLoadPromise :
-                                PlyLoader.loadFromFileData(plyFileData, minimumAlpha, compressionLevel, sectionSize, sceneCenter,
-                                                           blockSize, bucketSize, outSphericalHarmonicsDegree);
+                                PlyLoader.loadFromFileData(plyFileData, minimumAlpha, compressionLevel, outSphericalHarmonicsDegree,
+                                                           sectionSize, sceneCenter, blockSize, bucketSize);
             return loadPromise.then((splatBuffer) => {
                 if (onProgress) onProgress(100, '100%', LoaderStatus.Done);
                 return splatBuffer;
@@ -202,8 +202,8 @@ export class PlyLoader {
         });
     }
 
-    static loadFromFileData(plyFileData, minimumAlpha, compressionLevel, sectionSize,
-                            sceneCenter, blockSize, bucketSize, outSphericalHarmonicsDegree = 0) {
+    static loadFromFileData(plyFileData, minimumAlpha, compressionLevel, outSphericalHarmonicsDegree = 0,
+                            sectionSize, sceneCenter, blockSize, bucketSize) {
         return delayedExecute(() => {
             return PlyParser.parseToUncompressedSplatArray(plyFileData, outSphericalHarmonicsDegree);
         })

--- a/src/loaders/ply/PlyLoader.js
+++ b/src/loaders/ply/PlyLoader.js
@@ -98,8 +98,7 @@ export class PlyLoader {
                             maxSplatCount: maxSplatCount,
                             splatCount: splatCount,
                             compressionLevel: 0,
-                            sceneCenter: new THREE.Vector3(),
-                            sphericalHarmonicsDegree: outSphericalHarmonicsDegree
+                            sceneCenter: new THREE.Vector3()
                         }, streamBufferOut);
 
                         numBytesStreamed = header.headerSizeBytes;
@@ -156,7 +155,8 @@ export class PlyLoader {
                                     compressionScaleRange: 0,
                                     storageSizeBytes: 0,
                                     fullBucketCount: 0,
-                                    partiallyFilledBucketCount: 0
+                                    partiallyFilledBucketCount: 0,
+                                    sphericalHarmonicsDegree: outSphericalHarmonicsDegree
                                 }, 0, streamBufferOut, SplatBuffer.HeaderSizeBytes);
                                 streamedSplatBuffer = new SplatBuffer(streamBufferOut, false);
                             }

--- a/src/loaders/ply/PlyParser.js
+++ b/src/loaders/ply/PlyParser.js
@@ -93,7 +93,7 @@ export class PlyParser {
         if (sphericalHarmonicsDegree >= 1) {
             for (let i = 0; i < 3; i++) {
                 for (let rgb = 0; rgb < 3; rgb++) {
-                    sphericalHarmonicsDegree1Fields.push('f_rest_' + (i + sphericalHarmonicsCoefficientsPerChannel * rgb));
+                    sphericalHarmonicsDegree1Fields.push('f_rest_' + (i * sphericalHarmonicsCoefficientsPerChannel + rgb));
                 }
             }
         }

--- a/src/loaders/ply/PlyParser.js
+++ b/src/loaders/ply/PlyParser.js
@@ -205,32 +205,13 @@ export class PlyParser {
                 const outSphericalHarmonics = new Float32Array(toBuffer, outBase + outBytesPerCenter + outBytesPerScale +
                                                                outBytesPerRotation + outBytesPerColor,
                                                                parsedSplat.sphericalHarmonicsCount);
-                outSphericalHarmonics[0] = parsedSplat[UncompressedSplatArray.OFFSET.FRC0];
-                outSphericalHarmonics[1] = parsedSplat[UncompressedSplatArray.OFFSET.FRC1];
-                outSphericalHarmonics[2] = parsedSplat[UncompressedSplatArray.OFFSET.FRC2];
-                outSphericalHarmonics[3] = parsedSplat[UncompressedSplatArray.OFFSET.FRC3];
-                outSphericalHarmonics[4] = parsedSplat[UncompressedSplatArray.OFFSET.FRC4];
-                outSphericalHarmonics[5] = parsedSplat[UncompressedSplatArray.OFFSET.FRC5];
-                outSphericalHarmonics[6] = parsedSplat[UncompressedSplatArray.OFFSET.FRC6];
-                outSphericalHarmonics[7] = parsedSplat[UncompressedSplatArray.OFFSET.FRC7];
-                outSphericalHarmonics[8] = parsedSplat[UncompressedSplatArray.OFFSET.FRC8];
-
+                for (let i = 0; i <= 8; i++) {
+                    outSphericalHarmonics[i] = parsedSplat[UncompressedSplatArray.OFFSET.FRC0 + i];
+                }
                 if (outSphericalHarmonicsDegree >= 2) {
-                    outSphericalHarmonics[9] = parsedSplat[UncompressedSplatArray.OFFSET.FRC9];
-                    outSphericalHarmonics[10] = parsedSplat[UncompressedSplatArray.OFFSET.FRC10];
-                    outSphericalHarmonics[11] = parsedSplat[UncompressedSplatArray.OFFSET.FRC11];
-                    outSphericalHarmonics[12] = parsedSplat[UncompressedSplatArray.OFFSET.FRC12];
-                    outSphericalHarmonics[13] = parsedSplat[UncompressedSplatArray.OFFSET.FRC13];
-                    outSphericalHarmonics[14] = parsedSplat[UncompressedSplatArray.OFFSET.FRC14];
-                    outSphericalHarmonics[15] = parsedSplat[UncompressedSplatArray.OFFSET.FRC15];
-                    outSphericalHarmonics[16] = parsedSplat[UncompressedSplatArray.OFFSET.FRC16];
-                    outSphericalHarmonics[17] = parsedSplat[UncompressedSplatArray.OFFSET.FRC17];
-                    outSphericalHarmonics[18] = parsedSplat[UncompressedSplatArray.OFFSET.FRC18];
-                    outSphericalHarmonics[19] = parsedSplat[UncompressedSplatArray.OFFSET.FRC19];
-                    outSphericalHarmonics[20] = parsedSplat[UncompressedSplatArray.OFFSET.FRC20];
-                    outSphericalHarmonics[21] = parsedSplat[UncompressedSplatArray.OFFSET.FRC21];
-                    outSphericalHarmonics[22] = parsedSplat[UncompressedSplatArray.OFFSET.FRC22];
-                    outSphericalHarmonics[23] = parsedSplat[UncompressedSplatArray.OFFSET.FRC23];
+                    for (let i = 9; i <= 23; i++) {
+                        outSphericalHarmonics[i] = parsedSplat[UncompressedSplatArray.OFFSET.FRC0 + i];
+                    }
                 }
             }
         }
@@ -282,33 +263,13 @@ export class PlyParser {
 
             if (outSphericalHarmonicsDegree >= 1) {
                 if (rawVertex['f_rest_0'] !== undefined) {
-                    newSplat[UncompressedSplatArray.OFFSET.FRC0] = rawVertex[header.sphericalHarmonicsDegree1Fields[0]];
-                    newSplat[UncompressedSplatArray.OFFSET.FRC1] = rawVertex[header.sphericalHarmonicsDegree1Fields[1]];
-                    newSplat[UncompressedSplatArray.OFFSET.FRC2] = rawVertex[header.sphericalHarmonicsDegree1Fields[2]];
-                    newSplat[UncompressedSplatArray.OFFSET.FRC3] = rawVertex[header.sphericalHarmonicsDegree1Fields[3]];
-                    newSplat[UncompressedSplatArray.OFFSET.FRC4] = rawVertex[header.sphericalHarmonicsDegree1Fields[4]];
-                    newSplat[UncompressedSplatArray.OFFSET.FRC5] = rawVertex[header.sphericalHarmonicsDegree1Fields[5]];
-                    newSplat[UncompressedSplatArray.OFFSET.FRC6] = rawVertex[header.sphericalHarmonicsDegree1Fields[6]];
-                    newSplat[UncompressedSplatArray.OFFSET.FRC7] = rawVertex[header.sphericalHarmonicsDegree1Fields[7]];
-                    newSplat[UncompressedSplatArray.OFFSET.FRC8] = rawVertex[header.sphericalHarmonicsDegree1Fields[8]];
-
+                    for (let i = 0; i < 9; i++) {
+                        newSplat[UncompressedSplatArray.OFFSET.FRC0 + i] = rawVertex[header.sphericalHarmonicsDegree1Fields[i]];
+                    }
                     if (outSphericalHarmonicsDegree >= 2) {
-                        newSplat[UncompressedSplatArray.OFFSET.FRC9] = rawVertex[header.sphericalHarmonicsDegree2Fields[0]];
-                        newSplat[UncompressedSplatArray.OFFSET.FRC10] = rawVertex[header.sphericalHarmonicsDegree2Fields[1]];
-                        newSplat[UncompressedSplatArray.OFFSET.FRC11] = rawVertex[header.sphericalHarmonicsDegree2Fields[2]];
-                        newSplat[UncompressedSplatArray.OFFSET.FRC12] = rawVertex[header.sphericalHarmonicsDegree2Fields[3]];
-                        newSplat[UncompressedSplatArray.OFFSET.FRC13] = rawVertex[header.sphericalHarmonicsDegree2Fields[4]];
-                        newSplat[UncompressedSplatArray.OFFSET.FRC14] = rawVertex[header.sphericalHarmonicsDegree2Fields[5]];
-                        newSplat[UncompressedSplatArray.OFFSET.FRC15] = rawVertex[header.sphericalHarmonicsDegree2Fields[6]];
-                        newSplat[UncompressedSplatArray.OFFSET.FRC16] = rawVertex[header.sphericalHarmonicsDegree2Fields[7]];
-                        newSplat[UncompressedSplatArray.OFFSET.FRC17] = rawVertex[header.sphericalHarmonicsDegree2Fields[8]];
-                        newSplat[UncompressedSplatArray.OFFSET.FRC18] = rawVertex[header.sphericalHarmonicsDegree2Fields[9]];
-                        newSplat[UncompressedSplatArray.OFFSET.FRC19] = rawVertex[header.sphericalHarmonicsDegree2Fields[10]];
-                        newSplat[UncompressedSplatArray.OFFSET.FRC20] = rawVertex[header.sphericalHarmonicsDegree2Fields[11]];
-                        newSplat[UncompressedSplatArray.OFFSET.FRC21] = rawVertex[header.sphericalHarmonicsDegree2Fields[12]];
-                        newSplat[UncompressedSplatArray.OFFSET.FRC22] = rawVertex[header.sphericalHarmonicsDegree2Fields[13]];
-                        newSplat[UncompressedSplatArray.OFFSET.FRC23] = rawVertex[header.sphericalHarmonicsDegree2Fields[14]];
-
+                        for (let i = 0; i < 15; i++) {
+                            newSplat[UncompressedSplatArray.OFFSET.FRC9 + i] = rawVertex[header.sphericalHarmonicsDegree2Fields[i]];
+                        }
                     }
                 } else {
                     newSplat[UncompressedSplatArray.OFFSET.FRC0] = 0;

--- a/src/loaders/ply/PlyParser.js
+++ b/src/loaders/ply/PlyParser.js
@@ -83,7 +83,8 @@ export class PlyParser {
             'headerLines': prunedLines,
             'headerSizeBytes': headerText.indexOf(PlyParser.HeaderEndToken) + PlyParser.HeaderEndToken.length + 1,
             'bytesPerSplat': bytesPerSplat,
-            'fieldOffsets': fieldOffsets
+            'fieldOffsets': fieldOffsets,
+            'sphericalHarmonicsLevels': 0
         };
     }
 
@@ -126,11 +127,12 @@ export class PlyParser {
         }
     }
 
-    static parseToUncompressedSplatBufferSection(header, fromSplat, toSplat, vertexData, vertexDataOffset, toBuffer, toOffset) {
+    static parseToUncompressedSplatBufferSection(header, fromSplat, toSplat, vertexData, vertexDataOffset,
+                                                 toBuffer, toOffset, sphericalHarmonicsLevel = 0) {
         const outBytesPerCenter = SplatBuffer.CompressionLevels[0].BytesPerCenter;
         const outBytesPerScale = SplatBuffer.CompressionLevels[0].BytesPerScale;
         const outBytesPerRotation = SplatBuffer.CompressionLevels[0].BytesPerRotation;
-        const outBytesPerSplat = SplatBuffer.CompressionLevels[0].BytesPerSplat;
+        const outBytesPerSplat = SplatBuffer.CompressionLevels[0].SphericalHarmonicsLevels[sphericalHarmonicsLevel].BytesPerSplat;
 
         for (let i = fromSplat; i <= toSplat; i++) {
 

--- a/src/loaders/ply/PlyParser.js
+++ b/src/loaders/ply/PlyParser.js
@@ -87,13 +87,24 @@ export class PlyParser {
             if (fieldName.startsWith('f_rest')) sphericalHarmonicsFieldCount++;
         }
         sphericalHarmonicsCoefficientsPerChannel = sphericalHarmonicsFieldCount / 3;
+        let sphericalHarmonicsDegree = 0;
+        if (sphericalHarmonicsCoefficientsPerChannel >= 3) sphericalHarmonicsDegree = 1;
+        if (sphericalHarmonicsCoefficientsPerChannel >= 8) sphericalHarmonicsDegree = 2;
 
         let sphericalHarmonicsDegree1Fields = [];
-        let sphericalHarmonicsDegree = sphericalHarmonicsCoefficientsPerChannel;
         if (sphericalHarmonicsDegree >= 1) {
-            for (let i = 0; i < 3; i++) {
-                for (let rgb = 0; rgb < 3; rgb++) {
-                    sphericalHarmonicsDegree1Fields.push('f_rest_' + (i * sphericalHarmonicsCoefficientsPerChannel + rgb));
+            for (let rgb = 0; rgb < 3; rgb++) {
+                for (let i = 0; i < 3; i++) {
+                    sphericalHarmonicsDegree1Fields.push('f_rest_' + (i + sphericalHarmonicsCoefficientsPerChannel * rgb));
+                }
+            }
+        }
+
+        let sphericalHarmonicsDegree2Fields = [];
+        if (sphericalHarmonicsDegree >= 2) {
+            for (let rgb = 0; rgb < 3; rgb++) {
+                for (let i = 0; i < 5; i++) {
+                    sphericalHarmonicsDegree2Fields.push('f_rest_' + (i + sphericalHarmonicsCoefficientsPerChannel * rgb + 3));
                 }
             }
         }
@@ -109,7 +120,8 @@ export class PlyParser {
             'fieldOffsets': fieldOffsets,
             'sphericalHarmonicsDegree': sphericalHarmonicsDegree,
             'sphericalHarmonicsCoefficientsPerChannel': sphericalHarmonicsCoefficientsPerChannel,
-            'sphericalHarmonicsDegree1Fields': sphericalHarmonicsDegree1Fields
+            'sphericalHarmonicsDegree1Fields': sphericalHarmonicsDegree1Fields,
+            'sphericalHarmonicsDegree2Fields': sphericalHarmonicsDegree2Fields
         };
     }
 
@@ -202,6 +214,24 @@ export class PlyParser {
                 outSphericalHarmonics[6] = parsedSplat[UncompressedSplatArray.OFFSET.FRC6];
                 outSphericalHarmonics[7] = parsedSplat[UncompressedSplatArray.OFFSET.FRC7];
                 outSphericalHarmonics[8] = parsedSplat[UncompressedSplatArray.OFFSET.FRC8];
+
+                if (outSphericalHarmonicsDegree >= 2) {
+                    outSphericalHarmonics[9] = parsedSplat[UncompressedSplatArray.OFFSET.FRC9];
+                    outSphericalHarmonics[10] = parsedSplat[UncompressedSplatArray.OFFSET.FRC10];
+                    outSphericalHarmonics[11] = parsedSplat[UncompressedSplatArray.OFFSET.FRC11];
+                    outSphericalHarmonics[12] = parsedSplat[UncompressedSplatArray.OFFSET.FRC12];
+                    outSphericalHarmonics[13] = parsedSplat[UncompressedSplatArray.OFFSET.FRC13];
+                    outSphericalHarmonics[14] = parsedSplat[UncompressedSplatArray.OFFSET.FRC14];
+                    outSphericalHarmonics[15] = parsedSplat[UncompressedSplatArray.OFFSET.FRC15];
+                    outSphericalHarmonics[16] = parsedSplat[UncompressedSplatArray.OFFSET.FRC16];
+                    outSphericalHarmonics[17] = parsedSplat[UncompressedSplatArray.OFFSET.FRC17];
+                    outSphericalHarmonics[18] = parsedSplat[UncompressedSplatArray.OFFSET.FRC18];
+                    outSphericalHarmonics[19] = parsedSplat[UncompressedSplatArray.OFFSET.FRC19];
+                    outSphericalHarmonics[20] = parsedSplat[UncompressedSplatArray.OFFSET.FRC20];
+                    outSphericalHarmonics[21] = parsedSplat[UncompressedSplatArray.OFFSET.FRC21];
+                    outSphericalHarmonics[22] = parsedSplat[UncompressedSplatArray.OFFSET.FRC22];
+                    outSphericalHarmonics[23] = parsedSplat[UncompressedSplatArray.OFFSET.FRC23];
+                }
             }
         }
     }
@@ -214,7 +244,7 @@ export class PlyParser {
         return function(vertexData, row, header, vertexDataOffset = 0, outSphericalHarmonicsDegree = 0) {
             outSphericalHarmonicsDegree = Math.min(outSphericalHarmonicsDegree, header.sphericalHarmonicsDegree);
             PlyParser.readRawVertexFast(vertexData, row * header.bytesPerSplat + vertexDataOffset, header.fieldOffsets,
-                                        PlyParser.Fields[outSphericalHarmonicsDegree], header.propertyTypes, rawVertex);
+                                        PlyParser.Fields[outSphericalHarmonicsDegree > 0 ? 1 : 0], header.propertyTypes, rawVertex);
             const newSplat = UncompressedSplatArray.createSplat(outSphericalHarmonicsDegree);
             if (rawVertex['scale_0'] !== undefined) {
                 newSplat[UncompressedSplatArray.OFFSET.SCALE0] = Math.exp(rawVertex['scale_0']);
@@ -261,6 +291,25 @@ export class PlyParser {
                     newSplat[UncompressedSplatArray.OFFSET.FRC6] = rawVertex[header.sphericalHarmonicsDegree1Fields[6]];
                     newSplat[UncompressedSplatArray.OFFSET.FRC7] = rawVertex[header.sphericalHarmonicsDegree1Fields[7]];
                     newSplat[UncompressedSplatArray.OFFSET.FRC8] = rawVertex[header.sphericalHarmonicsDegree1Fields[8]];
+
+                    if (outSphericalHarmonicsDegree >= 2) {
+                        newSplat[UncompressedSplatArray.OFFSET.FRC9] = rawVertex[header.sphericalHarmonicsDegree2Fields[0]];
+                        newSplat[UncompressedSplatArray.OFFSET.FRC10] = rawVertex[header.sphericalHarmonicsDegree2Fields[1]];
+                        newSplat[UncompressedSplatArray.OFFSET.FRC11] = rawVertex[header.sphericalHarmonicsDegree2Fields[2]];
+                        newSplat[UncompressedSplatArray.OFFSET.FRC12] = rawVertex[header.sphericalHarmonicsDegree2Fields[3]];
+                        newSplat[UncompressedSplatArray.OFFSET.FRC13] = rawVertex[header.sphericalHarmonicsDegree2Fields[4]];
+                        newSplat[UncompressedSplatArray.OFFSET.FRC14] = rawVertex[header.sphericalHarmonicsDegree2Fields[5]];
+                        newSplat[UncompressedSplatArray.OFFSET.FRC15] = rawVertex[header.sphericalHarmonicsDegree2Fields[6]];
+                        newSplat[UncompressedSplatArray.OFFSET.FRC16] = rawVertex[header.sphericalHarmonicsDegree2Fields[7]];
+                        newSplat[UncompressedSplatArray.OFFSET.FRC17] = rawVertex[header.sphericalHarmonicsDegree2Fields[8]];
+                        newSplat[UncompressedSplatArray.OFFSET.FRC18] = rawVertex[header.sphericalHarmonicsDegree2Fields[9]];
+                        newSplat[UncompressedSplatArray.OFFSET.FRC19] = rawVertex[header.sphericalHarmonicsDegree2Fields[10]];
+                        newSplat[UncompressedSplatArray.OFFSET.FRC20] = rawVertex[header.sphericalHarmonicsDegree2Fields[11]];
+                        newSplat[UncompressedSplatArray.OFFSET.FRC21] = rawVertex[header.sphericalHarmonicsDegree2Fields[12]];
+                        newSplat[UncompressedSplatArray.OFFSET.FRC22] = rawVertex[header.sphericalHarmonicsDegree2Fields[13]];
+                        newSplat[UncompressedSplatArray.OFFSET.FRC23] = rawVertex[header.sphericalHarmonicsDegree2Fields[14]];
+
+                    }
                 } else {
                     newSplat[UncompressedSplatArray.OFFSET.FRC0] = 0;
                     newSplat[UncompressedSplatArray.OFFSET.FRC1] = 0;

--- a/src/loaders/splat/SplatLoader.js
+++ b/src/loaders/splat/SplatLoader.js
@@ -37,7 +37,8 @@ export class SplatLoader {
                 if (!streamBufferIn) {
                     maxSplatCount = fileSize / SplatParser.RowSizeBytes;
                     streamBufferIn = new ArrayBuffer(fileSize);
-                    const splatBufferSizeBytes = splatDataOffsetBytes + SplatBuffer.CompressionLevels[0].BytesPerSplat * maxSplatCount;
+                    const bytesPerSplat =  SplatBuffer.CompressionLevels[0].SphericalHarmonicsLevels[0].BytesPerSplat;
+                    const splatBufferSizeBytes = splatDataOffsetBytes + bytesPerSplat * maxSplatCount;
                     streamBufferOut = new ArrayBuffer(splatBufferSizeBytes);
                     SplatBuffer.writeHeaderToBuffer({
                         versionMajor: SplatBuffer.CurrentMajorVersion,

--- a/src/loaders/splat/SplatLoader.js
+++ b/src/loaders/splat/SplatLoader.js
@@ -37,7 +37,7 @@ export class SplatLoader {
                 if (!streamBufferIn) {
                     maxSplatCount = fileSize / SplatParser.RowSizeBytes;
                     streamBufferIn = new ArrayBuffer(fileSize);
-                    const bytesPerSplat =  SplatBuffer.CompressionLevels[0].SphericalHarmonicsLevels[0].BytesPerSplat;
+                    const bytesPerSplat = SplatBuffer.CompressionLevels[0].SphericalHarmonicsDegrees[0].BytesPerSplat;
                     const splatBufferSizeBytes = splatDataOffsetBytes + bytesPerSplat * maxSplatCount;
                     streamBufferOut = new ArrayBuffer(splatBufferSizeBytes);
                     SplatBuffer.writeHeaderToBuffer({

--- a/src/loaders/splat/SplatParser.js
+++ b/src/loaders/splat/SplatParser.js
@@ -15,7 +15,7 @@ export class SplatParser {
         const outBytesPerCenter = SplatBuffer.CompressionLevels[0].BytesPerCenter;
         const outBytesPerScale = SplatBuffer.CompressionLevels[0].BytesPerScale;
         const outBytesPerRotation = SplatBuffer.CompressionLevels[0].BytesPerRotation;
-        const outBytesPerSplat = SplatBuffer.CompressionLevels[0].BytesPerSplat;
+        const outBytesPerSplat = SplatBuffer.CompressionLevels[0].SphericalHarmonicsLevels[0].BytesPerSplat;
 
         for (let i = fromSplat; i <= toSplat; i++) {
             const inBase = i * SplatParser.RowSizeBytes + fromOffset;

--- a/src/loaders/splat/SplatParser.js
+++ b/src/loaders/splat/SplatParser.js
@@ -15,7 +15,7 @@ export class SplatParser {
         const outBytesPerCenter = SplatBuffer.CompressionLevels[0].BytesPerCenter;
         const outBytesPerScale = SplatBuffer.CompressionLevels[0].BytesPerScale;
         const outBytesPerRotation = SplatBuffer.CompressionLevels[0].BytesPerRotation;
-        const outBytesPerSplat = SplatBuffer.CompressionLevels[0].SphericalHarmonicsLevels[0].BytesPerSplat;
+        const outBytesPerSplat = SplatBuffer.CompressionLevels[0].SphericalHarmonicsDegrees[0].BytesPerSplat;
 
         for (let i = fromSplat; i <= toSplat; i++) {
             const inBase = i * SplatParser.RowSizeBytes + fromOffset;

--- a/util/create-ksplat.js
+++ b/util/create-ksplat.js
@@ -10,12 +10,12 @@ if (process.argv.length < 4) {
 
 const intputFile = process.argv[2];
 const outputFile = process.argv[3];
-const splatAlphaRemovalThreshold = (process.argv.length >= 6) ? parseInt(process.argv[5]) : undefined;
 const compressionLevel = (process.argv.length >= 5) ? parseInt(process.argv[4]) : undefined;
-const sceneCenter = (process.argv.length >= 6) ? new THREE.Vector3().fromArray(process.argv[5].split(',')) : undefined;
-const blockSize = (process.argv.length >= 7) ? parseFloat(process.argv[6]) : undefined;
-const bucketSize = (process.argv.length >= 8) ? parseInt(process.argv[7]) : undefined;
-const outSphericalHarmonicsDegree = (process.argv.length >= 9) ? parseInt(process.argv[8]) : undefined;
+const splatAlphaRemovalThreshold = (process.argv.length >= 6) ? parseInt(process.argv[5]) : undefined;
+const sceneCenter = (process.argv.length >= 7) ? new THREE.Vector3().fromArray(process.argv[6].split(',')) : undefined;
+const blockSize = (process.argv.length >= 8) ? parseFloat(process.argv[7]) : undefined;
+const bucketSize = (process.argv.length >= 9) ? parseInt(process.argv[8]) : undefined;
+const outSphericalHarmonicsDegree = (process.argv.length >= 10) ? parseInt(process.argv[9]) : undefined;
 const sectionSize = 0;
 
 const fileData = fs.readFileSync(intputFile);
@@ -30,13 +30,13 @@ function fileBufferToSplatBuffer(fileBufferData, format, compressionLevel, alpha
     if (format === GaussianSplats3D.SceneFormat.Ply || format === GaussianSplats3D.SceneFormat.Splat) {
         let splatArray;
         if (format === GaussianSplats3D.SceneFormat.Ply) {
-            splatArray = GaussianSplats3D.PlyParser.parseToUncompressedSplatArray(fileBufferData);
+            splatArray = GaussianSplats3D.PlyParser.parseToUncompressedSplatArray(fileBufferData, outSphericalHarmonicsDegree);
         } else {
             splatArray = GaussianSplats3D.SplatParser.parseStandardSplatToUncompressedSplatArray(fileBufferData);
         }
         const splatBufferGenerator = GaussianSplats3D.SplatBufferGenerator.getStandardGenerator(alphaRemovalThreshold, compressionLevel,
                                                                                                 sectionSize, sceneCenter, blockSize,
-                                                                                                bucketSize, outSphericalHarmonicsDegree);
+                                                                                                bucketSize);
         splatBuffer = splatBufferGenerator.generateFromUncompressedSplatArray(splatArray);
     } else {
         splatBuffer = new GaussianSplats3D.SplatBuffer(fileBufferData);

--- a/util/create-ksplat.js
+++ b/util/create-ksplat.js
@@ -4,7 +4,7 @@ import * as fs from 'fs';
 
 if (process.argv.length < 4) {
     console.log('Expected at least 2 arguments!');
-    console.log('Usage: node create-ksplat.js [path to .PLY or .SPLAT] [output file name] [compression level = 0] [alpha removal threshold = 1] [scene center = "0,0,0"] [block size = 5.0] [bucket size = 256]');
+    console.log('Usage: node create-ksplat.js [path to .PLY or .SPLAT] [output file name] [compression level = 0] [alpha removal threshold = 1] [scene center = "0,0,0"] [block size = 5.0] [bucket size = 256] [spherical harmonics level = 0]');
     process.exit(1);
 }
 
@@ -15,6 +15,7 @@ const compressionLevel = (process.argv.length >= 5) ? parseInt(process.argv[4]) 
 const sceneCenter = (process.argv.length >= 6) ? new THREE.Vector3().fromArray(process.argv[5].split(',')) : undefined;
 const blockSize = (process.argv.length >= 7) ? parseFloat(process.argv[6]) : undefined;
 const bucketSize = (process.argv.length >= 8) ? parseInt(process.argv[7]) : undefined;
+const outSphericalHarmonicsLevel = (process.argv.length >= 9) ? parseInt(process.argv[8]) : undefined;
 const sectionSize = 0;
 
 const fileData = fs.readFileSync(intputFile);
@@ -34,7 +35,8 @@ function fileBufferToSplatBuffer(fileBufferData, format, compressionLevel, alpha
             splatArray = GaussianSplats3D.SplatParser.parseStandardSplatToUncompressedSplatArray(fileBufferData);
         }
         const splatBufferGenerator = GaussianSplats3D.SplatBufferGenerator.getStandardGenerator(alphaRemovalThreshold, compressionLevel,
-                                                                                                sectionSize, sceneCenter, blockSize, bucketSize);
+                                                                                                sectionSize, sceneCenter, blockSize,
+                                                                                                bucketSize, outSphericalHarmonicsLevel);
         splatBuffer = splatBufferGenerator.generateFromUncompressedSplatArray(splatArray);
     } else {
         splatBuffer = new GaussianSplats3D.SplatBuffer(fileBufferData);

--- a/util/create-ksplat.js
+++ b/util/create-ksplat.js
@@ -15,7 +15,7 @@ const compressionLevel = (process.argv.length >= 5) ? parseInt(process.argv[4]) 
 const sceneCenter = (process.argv.length >= 6) ? new THREE.Vector3().fromArray(process.argv[5].split(',')) : undefined;
 const blockSize = (process.argv.length >= 7) ? parseFloat(process.argv[6]) : undefined;
 const bucketSize = (process.argv.length >= 8) ? parseInt(process.argv[7]) : undefined;
-const outSphericalHarmonicsLevel = (process.argv.length >= 9) ? parseInt(process.argv[8]) : undefined;
+const outSphericalHarmonicsDegree = (process.argv.length >= 9) ? parseInt(process.argv[8]) : undefined;
 const sectionSize = 0;
 
 const fileData = fs.readFileSync(intputFile);
@@ -36,7 +36,7 @@ function fileBufferToSplatBuffer(fileBufferData, format, compressionLevel, alpha
         }
         const splatBufferGenerator = GaussianSplats3D.SplatBufferGenerator.getStandardGenerator(alphaRemovalThreshold, compressionLevel,
                                                                                                 sectionSize, sceneCenter, blockSize,
-                                                                                                bucketSize, outSphericalHarmonicsLevel);
+                                                                                                bucketSize, outSphericalHarmonicsDegree);
         splatBuffer = splatBufferGenerator.generateFromUncompressedSplatArray(splatArray);
     } else {
         splatBuffer = new GaussianSplats3D.SplatBuffer(fileBufferData);


### PR DESCRIPTION
- Added support for 1st & 2nd degree spherical harmonics
- Added `Viewer` constructor parameter to enable: `sphericalHarmonicsDegree`. Default value is 0.
- Updated `.ksplat` format to include spherical harmonics
- Added new compression level for `.ksplat` files (2) that is identical to (1) except spherical harmonics are compressed to 8-bit
- Various bug fixes