### PR TITLE
Filter the path with parameters. Only the path is reserved

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Parameters for `addSplatScene()`
 | `rotation` | Rotation of the scene represented as a quaternion, defaults to `[0, 0, 0, 1]` (identity quaternion).
 | `scale` | Scene's scale, defaults to `[1, 1, 1]`.
 | `streamView` | Stream the scene's splat data and allow the scene to be rendered and viewed as the splats are loaded. Option is only valid for `addSplatScene()`, and not for `addSplatScenes()`.
+| `format` | Format supports a specified value. Include the following {'Splat':0, 'KSplat':1, 'Ply':2 }.  Defaults to `null`. Format If not set, will get the suffix from the url.
 
 <br>
 

--- a/src/loaders/Utils.js
+++ b/src/loaders/Utils.js
@@ -1,8 +1,16 @@
 import { SceneFormat } from './SceneFormat.js';
 
 export const sceneFormatFromPath = (path) => {
+    path = getPathFromURL(path);
     if (path.endsWith('.ply')) return SceneFormat.Ply;
     else if (path.endsWith('.splat')) return SceneFormat.Splat;
     else if (path.endsWith('.ksplat')) return SceneFormat.KSplat;
     return null;
 };
+
+
+function getPathFromURL(url) {
+    const regex = /^[^?#]*(?=\?|\#|$)/;
+    const match = regex.exec(url);
+    return match ? match[0] : '';
+}


### PR DESCRIPTION
Hello! Thank you for the project.

## Overview
I found a problem with the incoming url. If I use a url with parameters, I don't get the type right。

## Notes
I changed the sceneFormatFromPath method, added the ability to filter parameters, and adjusted the parameter description of addSplatScene in readme