### PR TITLE
2D Gaussian Splatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ Advanced `Viewer` parameters
 | `enableOptionalEffects` | When true, allows for usage of extra properties and attributes during rendering for effects such as opacity adjustment. Default is `false` for performance reasons. These properties are separate from transform properties (scale, rotation, position) that are enabled by the `dynamicScene` parameter.
 | `plyInMemoryCompressionLevel` | Level to compress `.ply` files when loading them for direct rendering (not exporting to `.ksplat`). Valid values are the same as `.ksplat` compression levels (0, 1, or 2). Default is 2.
 | `freeIntermediateSplatData` | When true, the intermediate splat data that is the result of decompressing splat bufffer(s) and used to populate data textures will be freed. This will reduces memory usage, but if that data needs to be modified it will need to be re-populated from the splat buffer(s). Defaults to `false`.
+| `splatRenderMode` | Determine which splat rendering mode to enable. Valid values are defined in the `SplatRenderMode` enum: `ThreeD` and `TwoD`. `ThreeD` is the original/traditional mode and `TwoD` is the new mode described here: https://surfsplatting.github.io/
 <br>
 
 ### Creating KSPLAT files

--- a/README.md
+++ b/README.md
@@ -30,12 +30,23 @@ When I started, web-based viewers were already available -- A WebGL-based viewer
 - Custom `.ksplat` file format still needs work, especially around compression
 - The default, integer based splat sort does not work well for larger scenes. In that case a value of `false` for the `integerBasedSort` viewer parameter can force a slower, floating-point based sort
 
+## Limitations
+
+Currently there are limits on the number of splats that can be rendered, and those limits depend mainly on the degree of spherical harmonics desired. Those limits are:
+
+| Spherical harmonics degree | Max splat count
+| --- | ---
+| `0` | ~ 16,000,000
+| `1` | ~ 11,000,000
+| `2` | ~ 8,000,000
+
+Future work will include optimizing how splat data is packed into data textures, which will help increase these limits.
+
 ## Future work
 This is still very much a work in progress! There are several things that still need to be done:
-  - Improve the method by which splat data is stored in textures
+  - Improve the way splat data is packed into data textures
   - Continue optimizing CPU-based splat sort - maybe try an incremental sort of some kind?
-  - Add editing mode, allowing users to modify scene and export changes
-  - Support very large scenes
+  - Support very large scenes (streaming sections & LOD)
 
 ## Online demo
 [https://projects.markkellogg.org/threejs/demo_gaussian_splats_3d.php](https://projects.markkellogg.org/threejs/demo_gaussian_splats_3d.php)

--- a/src/DropInViewer.js
+++ b/src/DropInViewer.js
@@ -20,11 +20,26 @@ export class DropInViewer extends THREE.Group {
 
         this.viewer = new Viewer(options);
         this.splatMesh = null;
+        this.updateSplatMesh();
 
         this.callbackMesh = DropInViewer.createCallbackMesh();
         this.add(this.callbackMesh);
         this.callbackMesh.onBeforeRender = DropInViewer.onBeforeRender.bind(this, this.viewer);
 
+        this.viewer.onSplatMeshChanged(() => {
+            this.updateSplatMesh();
+        });
+
+    }
+
+    updateSplatMesh() {
+        if (this.splatMesh !== this.viewer.splatMesh) {
+            if (this.splatMesh) {
+                this.remove(this.splatMesh);
+            }
+            this.splatMesh = this.viewer.splatMesh;
+            this.add(this.viewer.splatMesh);
+        }
     }
 
     /**
@@ -85,8 +100,12 @@ export class DropInViewer extends THREE.Group {
         return this.viewer.getSplatScene(sceneIndex);
     }
 
-    removeSplatScene(index) {
-        return this.viewer.removeSplatScene(index);
+    removeSplatScene(index, showLoadingUI = true) {
+        return this.viewer.removeSplatScene(index, showLoadingUI);
+    }
+
+    removeSplatScenes(indexes, showLoadingUI = true) {
+        return this.viewer.removeSplatScenes(indexes, showLoadingUI);
     }
 
     dispose() {
@@ -94,13 +113,6 @@ export class DropInViewer extends THREE.Group {
     }
 
     static onBeforeRender(viewer, renderer, threeScene, camera) {
-        if (this.splatMesh !== this.viewer.splatMesh) {
-            if (this.splatMesh) {
-                this.remove(this.splatMesh);
-            }
-            this.splatMesh = this.viewer.splatMesh;
-            this.add(this.viewer.splatMesh);
-        }
         viewer.update(renderer, camera);
     }
 

--- a/src/SplatRenderMode.js
+++ b/src/SplatRenderMode.js
@@ -1,0 +1,4 @@
+export const SplatRenderMode = {
+    ThreeD: 0,
+    TwoD: 1
+};

--- a/src/Viewer.js
+++ b/src/Viewer.js
@@ -23,6 +23,7 @@ import { LoaderStatus } from './loaders/LoaderStatus.js';
 import { RenderMode } from './RenderMode.js';
 import { LogLevel } from './LogLevel.js';
 import { SceneRevealMode } from './SceneRevealMode.js';
+import { SplatRenderMode } from './SplatRenderMode.js';
 
 const THREE_CAMERA_FOV = 50;
 const MINIMUM_DISTANCE_TO_NEW_FOCAL_POINT = .75;
@@ -180,6 +181,12 @@ export class Viewer {
             }
         }
 
+        // Tell the viewer how to render the splats
+        if (options.splatRenderMode === undefined || options.splatRenderMode === null) {
+            options.splatRenderMode = SplatRenderMode.ThreeD;
+        }
+        this.splatRenderMode = options.splatRenderMode;
+
         this.createSplatMesh();
 
         this.controls = null;
@@ -253,9 +260,10 @@ export class Viewer {
     }
 
     createSplatMesh() {
-        this.splatMesh = new SplatMesh(this.dynamicScene, this.enableOptionalEffects, this.halfPrecisionCovariancesOnGPU,
-                                       this.devicePixelRatio, this.gpuAcceleratedSort, this.integerBasedSort, this.antialiased,
-                                       this.maxScreenSpaceSplatSize, this.logLevel, this.sphericalHarmonicsDegree);
+        this.splatMesh = new SplatMesh(this.splatRenderMode, this.dynamicScene, this.enableOptionalEffects,
+                                       this.halfPrecisionCovariancesOnGPU, this.devicePixelRatio, this.gpuAcceleratedSort,
+                                       this.integerBasedSort, this.antialiased, this.maxScreenSpaceSplatSize, this.logLevel,
+                                       this.sphericalHarmonicsDegree);
         this.splatMesh.frustumCulled = false;
     }
 
@@ -1021,7 +1029,8 @@ export class Viewer {
             return PlyLoader.loadFromURL(path, onProgress, progressiveBuild, onSectionBuilt,
                                          splatAlphaRemovalThreshold, this.plyInMemoryCompressionLevel, this.sphericalHarmonicsDegree);
         }
-        return AbortablePromise.reject(new Error(`Viewer::downloadSplatSceneToSplatBuffer -> File format not supported: ${path}`));
+
+        throw new Error(`Viewer::downloadSplatSceneToSplatBuffer -> File format not supported: ${path}`);
     }
 
     static isProgressivelyLoadable(format) {

--- a/src/Viewer.js
+++ b/src/Viewer.js
@@ -374,7 +374,7 @@ export class Viewer {
                     this.perspectiveControls = new OrbitControls(this.camera, this.renderer.domElement);
                 }
             }
-            for (let controls of [this.perspectiveControls, this.orthographicControls]) {
+            for (let controls of [this.orthographicControls, this.perspectiveControls,]) {
                 if (controls) {
                     controls.listenToKeyEvents(window);
                     controls.rotateSpeed = 0.5;
@@ -383,9 +383,11 @@ export class Viewer {
                     controls.enableDamping = true;
                     controls.dampingFactor = 0.05;
                     controls.target.copy(this.initialCameraLookAt);
+                    controls.update();
                 }
             }
             this.controls = this.camera.isOrthographicCamera ? this.orthographicControls : this.perspectiveControls;
+            this.controls.update();
         }
     }
 

--- a/src/Viewer.js
+++ b/src/Viewer.js
@@ -143,7 +143,7 @@ export class Viewer {
         this.logLevel = options.logLevel || LogLevel.None;
 
         // Degree of spherical harmonics to utilize in rendering splats (assuming the data is present in the splat scene).
-        // Valid values are 0 - 3. Default value is 0.
+        // Valid values are 0 - 2. Default value is 0.
         this.sphericalHarmonicsDegree = options.sphericalHarmonicsDegree || 0;
 
         // When true, allows for usage of extra properties and attributes during rendering for effects such as opacity adjustment.

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,7 @@ import { WebXRMode } from './webxr/WebXRMode.js';
 import { RenderMode } from './RenderMode.js';
 import { LogLevel } from './LogLevel.js';
 import { SceneRevealMode } from './SceneRevealMode.js';
+import { SplatRenderMode } from './SplatRenderMode.js';
 
 export {
     PlyParser,
@@ -37,5 +38,6 @@ export {
     WebXRMode,
     RenderMode,
     LogLevel,
-    SceneRevealMode
+    SceneRevealMode,
+    SplatRenderMode
 };

--- a/src/loaders/SplatBuffer.js
+++ b/src/loaders/SplatBuffer.js
@@ -34,7 +34,7 @@ const fromHalfFloatToUint8 = (v) => {
 
 const fromUint8ToHalfFloat = (v) => {
     return toHalfFloat(fromUint8(v));
-}
+};
 
 const dataViewFloatForCompressionLevel = (dataView, floatIndex, compressionLevel, isSH = false) => {
     if (compressionLevel === 0) {
@@ -354,7 +354,7 @@ export class SplatBuffer {
             quaternion.y *= flip;
             quaternion.z *= flip;
             quaternion.w *= flip;
-        }
+        };
 
         return function(outScaleArray, outRotationArray, transform, srcFrom, srcTo, destFrom, desiredOutputCompressionLevel) {
             const splatCount = this.splatCount;

--- a/src/loaders/SplatBuffer.js
+++ b/src/loaders/SplatBuffer.js
@@ -6,7 +6,6 @@ import { Constants } from '../Constants.js';
 const SphericalHarmonics8BitCompressionHalfRange = Constants.SphericalHarmonics8BitCompressionRange / 2.0;
 
 const toHalfFloat = THREE.DataUtils.toHalfFloat.bind(THREE.DataUtils);
-
 const fromHalfFloat = THREE.DataUtils.fromHalfFloat.bind(THREE.DataUtils);
 
 const toUncompressedFloat = (f, compressionLevel, isSH = false) => {
@@ -507,6 +506,7 @@ export class SplatBuffer {
             scale.set(toUncompressedFloat(dataViewFloatForCompressionLevel(dataView, 0, this.compressionLevel), this.compressionLevel),
                       toUncompressedFloat(dataViewFloatForCompressionLevel(dataView, 1, this.compressionLevel), this.compressionLevel),
                       toUncompressedFloat(dataViewFloatForCompressionLevel(dataView, 2, this.compressionLevel), this.compressionLevel));
+
             rotation.set(toUncompressedFloat(dataViewFloatForCompressionLevel(dataView, 4, this.compressionLevel), this.compressionLevel),
                          toUncompressedFloat(dataViewFloatForCompressionLevel(dataView, 5, this.compressionLevel), this.compressionLevel),
                          toUncompressedFloat(dataViewFloatForCompressionLevel(dataView, 6, this.compressionLevel), this.compressionLevel),

--- a/src/loaders/ply/INRIAV1PlyParser.js
+++ b/src/loaders/ply/INRIAV1PlyParser.js
@@ -35,7 +35,8 @@ export class INRIAV1PlyParser {
             shFieldsToReadCount = 9;
         }
 
-        let shRemainingFieldNamesToRead = Array.from(Array(shFieldsToReadCount - 1)).map((element, index) => `f_rest_${index + 1}`);
+        const shFieldIndexesToMap = Array.from(Array(Math.max(shFieldsToReadCount - 1, 0)));
+        let shRemainingFieldNamesToRead = shFieldIndexesToMap.map((element, index) => `f_rest_${index + 1}`);
 
         const fieldNamesToRead = [...BaseFieldNamesToRead, ...shRemainingFieldNamesToRead];
         const fieldsToReadIndexes = fieldNamesToRead.map((e, i) => i);

--- a/src/raycaster/Raycaster.js
+++ b/src/raycaster/Raycaster.js
@@ -1,6 +1,7 @@
 import * as THREE from 'three';
 import { Ray } from './Ray.js';
 import { Hit } from './Hit.js';
+import { SplatRenderMode } from '../SplatRenderMode.js';
 
 export class Raycaster {
 
@@ -121,7 +122,13 @@ export class Raycaster {
                     }
 
                     if (!this.raycastAgainstTrueSplatEllipsoid) {
-                        const radius = (tempScale.x + tempScale.y + tempScale.z) / 3;
+                        let radius = (tempScale.x + tempScale.y);
+                        let componentCount = 2;
+                        if (splatTree.splatMesh.splatRenderMode === SplatRenderMode.ThreeD) {
+                            radius += tempScale.z;
+                            componentCount = 3;
+                        }
+                        radius = radius / componentCount;
                         if (ray.intersectSphere(tempCenter, radius, tempHit)) {
                             const hitClone = tempHit.clone();
                             hitClone.splatIndex = splatGlobalIndex;

--- a/src/raycaster/Raycaster.js
+++ b/src/raycaster/Raycaster.js
@@ -117,7 +117,8 @@ export class Raycaster {
                     splatTree.splatMesh.getSplatCenter(splatGlobalIndex, tempCenter);
                     splatTree.splatMesh.getSplatScaleAndRotation(splatGlobalIndex, tempScale, tempRotation);
 
-                    if (tempScale.x <= scaleEpsilon || tempScale.y <= scaleEpsilon || tempScale.z <= scaleEpsilon) {
+                    if (tempScale.x <= scaleEpsilon || tempScale.y <= scaleEpsilon ||
+                        splatTree.splatMesh.splatRenderMode === SplatRenderMode.ThreeD && tempScale.z <= scaleEpsilon) {
                         continue;
                     }
 

--- a/src/splatmesh/SplatMaterial.js
+++ b/src/splatmesh/SplatMaterial.js
@@ -398,48 +398,49 @@ export class SplatMaterial {
             `;
         } else {
             /*
-            const float2 xy = collected_xy[j];
-            const float3 Tu = collected_Tu[j];
-            const float3 Tv = collected_Tv[j];
-            const float3 Tw = collected_Tw[j];
-            float3 k = pix.x * Tw - Tu;
-            float3 l = pix.y * Tw - Tv;
-            float3 p = cross(k, l);
-            if (p.z == 0.0) continue;
-            float2 s = {p.x / p.z, p.y / p.z};
-            float rho3d = (s.x * s.x + s.y * s.y);
-            float2 d = {xy.x - pixf.x, xy.y - pixf.y};
-            float rho2d = FilterInvSquare * (d.x * d.x + d.y * d.y);
+                const float2 xy = collected_xy[j];
+                const float3 Tu = collected_Tu[j];
+                const float3 Tv = collected_Tv[j];
+                const float3 Tw = collected_Tw[j];
+                float3 k = pix.x * Tw - Tu;
+                float3 l = pix.y * Tw - Tv;
+                float3 p = cross(k, l);
+                if (p.z == 0.0) continue;
+                float2 s = {p.x / p.z, p.y / p.z};
+                float rho3d = (s.x * s.x + s.y * s.y);
+                float2 d = {xy.x - pixf.x, xy.y - pixf.y};
+                float rho2d = FilterInvSquare * (d.x * d.x + d.y * d.y);
 
-            // compute intersection and depth
-            float rho = min(rho3d, rho2d);
-            float depth = (rho3d <= rho2d) ? (s.x * Tw.x + s.y * Tw.y) + Tw.z : Tw.z;
-            if (depth < near_n) continue;
-            float4 nor_o = collected_normal_opacity[j];
-            float normal[3] = {nor_o.x, nor_o.y, nor_o.z};
-            float opa = nor_o.w;
+                // compute intersection and depth
+                float rho = min(rho3d, rho2d);
+                float depth = (rho3d <= rho2d) ? (s.x * Tw.x + s.y * Tw.y) + Tw.z : Tw.z;
+                if (depth < near_n) continue;
+                float4 nor_o = collected_normal_opacity[j];
+                float normal[3] = {nor_o.x, nor_o.y, nor_o.z};
+                float opa = nor_o.w;
 
-            float power = -0.5f * rho;
-            if (power > 0.0f)
-                continue;
+                float power = -0.5f * rho;
+                if (power > 0.0f)
+                    continue;
 
-            // Eq. (2) from 3D Gaussian splatting paper.
-            // Obtain alpha by multiplying with Gaussian opacity
-            // and its exponential falloff from mean.
-            // Avoid numerical instabilities (see paper appendix).
-            float alpha = min(0.99f, opa * exp(power));
-            if (alpha < 1.0f / 255.0f)
-                continue;
-            float test_T = T * (1 - alpha);
-            if (test_T < 0.0001f)
-            {
-                done = true;
-                continue;
-            }
+                // Eq. (2) from 3D Gaussian splatting paper.
+                // Obtain alpha by multiplying with Gaussian opacity
+                // and its exponential falloff from mean.
+                // Avoid numerical instabilities (see paper appendix).
+                float alpha = min(0.99f, opa * exp(power));
+                if (alpha < 1.0f / 255.0f)
+                    continue;
+                float test_T = T * (1 - alpha);
+                if (test_T < 0.0001f)
+                {
+                    done = true;
+                    continue;
+                }
 
-            float w = alpha * T;
+                float w = alpha * T;
             */
             fragmentShaderSource += `
+
                 const float FilterInvSquare = 2.0;
                 const float near_n = 0.2;
                 const float T = 1.0;
@@ -461,8 +462,8 @@ export class SplatMaterial {
                 float rho = min(rho3d, rho2d);
                 float depth = (rho3d <= rho2d) ? (s.x * Tw.x + s.y * Tw.y) + Tw.z : Tw.z; 
                 if (depth < near_n) discard;
-              //  vec4 nor_o = collected_normal_opacity[j];
-            //    float normal[3] = {nor_o.x, nor_o.y, nor_o.z};
+                //  vec4 nor_o = collected_normal_opacity[j];
+                //  float normal[3] = {nor_o.x, nor_o.y, nor_o.z};
                 float opa = vColor.a;
 
                 float power = -0.5f * rho;
@@ -777,20 +778,6 @@ export class SplatMaterial {
                 // We use sqrt(8) standard deviations instead of 3 to eliminate more of the splat with a very low opacity.
                 vec2 basisVector1 = eigenVector1 * splatScale * min(sqrt8 * sqrt(eigenValue1), ${parseInt(maxScreenSpaceSplatSize)}.0);
                 vec2 basisVector2 = eigenVector2 * splatScale * min(sqrt8 * sqrt(eigenValue2), ${parseInt(maxScreenSpaceSplatSize)}.0);
-
-                if (fadeInComplete == 0) {
-                    float opacityAdjust = 1.0;
-                    float centerDist = length(splatCenter - sceneCenter);
-                    float renderTime = max(currentTime - firstRenderTime, 0.0);
-
-                    float fadeDistance = 0.75;
-                    float distanceLoadFadeInFactor = step(visibleRegionFadeStartRadius, centerDist);
-                    distanceLoadFadeInFactor = (1.0 - distanceLoadFadeInFactor) +
-                                               (1.0 - clamp((centerDist - visibleRegionFadeStartRadius) / fadeDistance, 0.0, 1.0)) *
-                                               distanceLoadFadeInFactor;
-                    opacityAdjust *= distanceLoadFadeInFactor;
-                    vColor.a *= opacityAdjust;
-                }
                 `;
 
             if (enableOptionalEffects) {
@@ -808,7 +795,7 @@ export class SplatMaterial {
 
                 // Scale the position data we send to the fragment shader
                 vPosition *= sqrt8;
-            }`;
+            `;
 
         } else {
             /*
@@ -856,8 +843,6 @@ export class SplatMaterial {
                 vec3 scaleRotation456 = vec3(scaleRotationA.a, scaleRotationB.rg) * (1.0 - fOddOffset) +
                                         vec3(scaleRotationB.gba) * fOddOffset;
 
-                // scaleRotation123 = vec3(0.01, 0.01, 0.0);
-                // scaleRotation456 = vec3(0.0, 0.0, 1.0);
                 float missingW = sqrt(1.0 - scaleRotation456.x * scaleRotation456.x - scaleRotation456.y *
                                       scaleRotation456.y - scaleRotation456.z * scaleRotation456.z);
                 mat3 R = quaternionToRotationMatrix(scaleRotation456.r, scaleRotation456.g, scaleRotation456.b, missingW);
@@ -882,70 +867,124 @@ export class SplatMaterial {
             `;
 
 
-            /*
-                float3 T0 = {T[0][0], T[0][1], T[0][2]};
-                float3 T1 = {T[1][0], T[1][1], T[1][2]};
-                float3 T3 = {T[2][0], T[2][1], T[2][2]};
+            const useRefImplementation = false;
+            if (useRefImplementation) {
 
-                // Compute AABB
-                float3 temp_point = {1.0f, 1.0f, -1.0f};
-                float distance = sumf3(T3 * T3 * temp_point);
-                float3 f = (1 / distance) * temp_point;
-                if (distance == 0.0) return false;
+                /*
+                    float3 T0 = {T[0][0], T[0][1], T[0][2]};
+                    float3 T1 = {T[1][0], T[1][1], T[1][2]};
+                    float3 T3 = {T[2][0], T[2][1], T[2][2]};
 
-                point_image = {
-                    sumf3(f * T0 * T3),
-                    sumf3(f * T1 * T3)
-                };
+                    // Compute AABB
+                    float3 temp_point = {1.0f, 1.0f, -1.0f};
+                    float distance = sumf3(T3 * T3 * temp_point);
+                    float3 f = (1 / distance) * temp_point;
+                    if (distance == 0.0) return false;
 
-                float2 temp = {
-                    sumf3(f * T0 * T0),
-                    sumf3(f * T1 * T1)
-                };
-                float2 half_extend = point_image * point_image - temp;
-                extent = sqrtf2(maxf2(1e-4, half_extend));
-                return true;
-            */
+                    point_image = {
+                        sumf3(f * T0 * T3),
+                        sumf3(f * T1 * T3)
+                    };
 
-            // Computing the bounding box of the 2D Gaussian and its center
-            // The center of the bounding box is used to create a low pass filter
-            vertexShaderSource += `
-               /* vec3 T0 = vec3(T[0][0], T[1][0], T[2][0]);
-                vec3 T1 = vec3(T[0][1], T[1][1], T[2][1]);
-                vec3 T3 = vec3(T[0][2], T[1][2], T[2][2]);*/
+                    float2 temp = {
+                        sumf3(f * T0 * T0),
+                        sumf3(f * T1 * T1)
+                    };
+                    float2 half_extend = point_image * point_image - temp;
+                    extent = sqrtf2(maxf2(1e-4, half_extend));
+                    return true;
+                */
 
-                vec3 T0 = vec3(T[0][0], T[0][1], T[0][2]);
-                vec3 T1 = vec3(T[1][0], T[1][1], T[1][2]);
-                vec3 T3 = vec3(T[2][0], T[2][1], T[2][2]);
+                // Computing the bounding box of the 2D Gaussian and its center
+                // The center of the bounding box is used to create a low pass filter.
+                // This code is based off the reference implementation and creates an AABB aligned
+                // with the screen for the quad to be rendered.
+                vertexShaderSource += `
+                    vec3 T0 = vec3(T[0][0], T[0][1], T[0][2]);
+                    vec3 T1 = vec3(T[1][0], T[1][1], T[1][2]);
+                    vec3 T3 = vec3(T[2][0], T[2][1], T[2][2]);
 
-                vec3 tempPoint = vec3(1.0, 1.0, -1.0);
-                // float distance = dot(T3 * T3, tempPoint);
-                float distance = (T3.x * T3.x * tempPoint.x) + (T3.y * T3.y * tempPoint.y) + (T3.z * T3.z * tempPoint.z);
-                vec3 f = (1.0 / distance) * tempPoint;
-                if (abs(distance) < 0.00001) return;
+                    vec3 tempPoint = vec3(1.0, 1.0, -1.0);
+                    float distance = (T3.x * T3.x * tempPoint.x) + (T3.y * T3.y * tempPoint.y) + (T3.z * T3.z * tempPoint.z);
+                    vec3 f = (1.0 / distance) * tempPoint;
+                    if (abs(distance) < 0.00001) return;
 
-                float pointImageX = (T0.x * T3.x * f.x) + (T0.y * T3.y * f.y) + (T0.z * T3.z * f.z);
-                float pointImageY = (T1.x * T3.x * f.x) + (T1.y * T3.y * f.y) + (T1.z * T3.z * f.z);
-                //vec2 pointImage = vec2(dot(T0 * T3, f), dot(T1 * T3, f));
-                vec2 pointImage = vec2(pointImageX, pointImageY);
-                float tempX = (T0.x * T0.x * f.x) + (T0.y * T0.y * f.y) + (T0.z * T0.z * f.z);
-                float tempY = (T1.x * T1.x * f.x) + (T1.y * T1.y * f.y) + (T1.z * T1.z * f.z);
-                // vec2 temp = vec2(dot(T0 * T0, f), dot(T1 * T1, f));
-                vec2 temp = vec2(tempX, tempY);
-                vec2 halfExtend = pointImage * pointImage - temp;
-                vec2 extent = sqrt(max(vec2(0.0001), halfExtend));
-                float radius = max(extent.x, extent.y);
+                    float pointImageX = (T0.x * T3.x * f.x) + (T0.y * T3.y * f.y) + (T0.z * T3.z * f.z);
+                    float pointImageY = (T1.x * T3.x * f.x) + (T1.y * T3.y * f.y) + (T1.z * T3.z * f.z);
+                    vec2 pointImage = vec2(pointImageX, pointImageY);
 
-                vec2 ndcOffset = ((position.xy * radius * 3.0) * basisViewport * 2.0);
+                    float tempX = (T0.x * T0.x * f.x) + (T0.y * T0.y * f.y) + (T0.z * T0.z * f.z);
+                    float tempY = (T1.x * T1.x * f.x) + (T1.y * T1.y * f.y) + (T1.z * T1.z * f.z);
+                    vec2 temp = vec2(tempX, tempY);
 
-                vec4 quadPos = vec4(ndcCenter.xy + ndcOffset, ndcCenter.z, 1.0);
-                gl_Position = quadPos;
+                    vec2 halfExtend = pointImage * pointImage - temp;
+                    vec2 extent = sqrt(max(vec2(0.0001), halfExtend));
+                    float radius = max(extent.x, extent.y);
 
-                vT = T;
-                vQuadCenter = pointImage;
-                vFragCoord = (quadPos.xy * 0.5 + 0.5) * viewport;
-            }`;
+                    vec2 ndcOffset = ((position.xy * radius * 3.0) * basisViewport * 2.0);
+
+                    vec4 quadPos = vec4(ndcCenter.xy + ndcOffset, ndcCenter.z, 1.0);
+                    gl_Position = quadPos;
+
+                    vT = T;
+                    vQuadCenter = pointImage;
+                    vFragCoord = (quadPos.xy * 0.5 + 0.5) * viewport;
+                `;
+            } else {
+
+                // Create a quad that is aligned with the eigen vectors of the projected gaussian for rendering.
+                // This is a different approach than the reference implementation, similar to how the rendering of
+                // 3D gaussians in this viewer differs from the reference implementation.
+                vertexShaderSource += `
+
+                    mat4 splat2World4 = mat4(vec4(L[0], 0.0),
+                                            vec4(L[1], 0.0),
+                                            vec4(L[2], 0.0),
+                                            vec4(splatCenter.x, splatCenter.y, splatCenter.z, 1.0));
+
+                    mat4 Tt = transpose(transpose(splat2World4) * world2ndc);
+
+                    vec4 tempPoint1 = Tt * vec4(1.0, 0.0, 0.0, 1.0);
+                    tempPoint1 /= tempPoint1.w;
+
+                    vec4 tempPoint2 = Tt * vec4(0.0, 1.0, 0.0, 1.0);
+                    tempPoint2 /= tempPoint2.w;
+
+                    vec4 center = Tt * vec4(0.0, 0.0, 0.0, 1.0);
+                    center /= center.w;
+
+                    vec2 basisVector1 = tempPoint1.xy - center.xy;
+                    vec2 basisVector2 = tempPoint2.xy - center.xy;
+
+                    vec2 ndcOffset = vec2(position.x * basisVector1 + position.y * basisVector2) * 3.0;
+                    vec4 quadPos = vec4(ndcCenter.xy + ndcOffset, ndcCenter.z, 1.0);
+                    gl_Position = quadPos;
+
+                    vT = T;
+                    vQuadCenter = center.xy;
+                    vFragCoord = (quadPos.xy * 0.5 + 0.5) * viewport;
+
+                `;
+            }
         }
+
+        vertexShaderSource += `
+            
+            if (fadeInComplete == 0) {
+                float opacityAdjust = 1.0;
+                float centerDist = length(splatCenter - sceneCenter);
+                float renderTime = max(currentTime - firstRenderTime, 0.0);
+
+                float fadeDistance = 0.75;
+                float distanceLoadFadeInFactor = step(visibleRegionFadeStartRadius, centerDist);
+                distanceLoadFadeInFactor = (1.0 - distanceLoadFadeInFactor) +
+                                        (1.0 - clamp((centerDist - visibleRegionFadeStartRadius) / fadeDistance, 0.0, 1.0)) *
+                                        distanceLoadFadeInFactor;
+                opacityAdjust *= distanceLoadFadeInFactor;
+                vColor.a *= opacityAdjust;
+            }
+        }
+        `;
 
         return vertexShaderSource;
     }

--- a/src/splatmesh/SplatMaterial.js
+++ b/src/splatmesh/SplatMaterial.js
@@ -1,491 +1,347 @@
 import * as THREE from 'three';
-import { SplatRenderMode } from '../SplatRenderMode.js';
 import { Constants } from '../Constants.js';
 
 export class SplatMaterial {
 
-    /**
-     * Build the Three.js material that is used to render the splats.
-     * @param {number} dynamicMode If true, it means the scene geometry represented by this splat mesh is not stationary or
-     *                             that the splat count might change
-     * @param {boolean} enableOptionalEffects When true, allows for usage of extra properties and attributes in the shader for effects
-     *                                        such as opacity adjustment. Default is false for performance reasons.
-     * @param {boolean} antialiased If true, calculate compensation factor to deal with gaussians being rendered at a significantly
-     *                              different resolution than that of their training
-     * @param {number} maxScreenSpaceSplatSize The maximum clip space splat size
-     * @param {number} splatScale Value by which all splats are scaled in screen-space (default is 1.0)
-     * @param {number} pointCloudModeEnabled Render all splats as screen-space circles
-     * @param {number} maxSphericalHarmonicsDegree Degree of spherical harmonics to utilize in rendering splats
-     * @return {THREE.ShaderMaterial}
-     */
-    static build(dynamicMode = false, splatRenderMode = SplatRenderMode.ThreeD, enableOptionalEffects = false, antialiased = false,
-                 maxScreenSpaceSplatSize = 2048, splatScale = 1.0, pointCloudModeEnabled = false, maxSphericalHarmonicsDegree = 0) {
-
-        // Contains the code to project 3D covariance to 2D and from there calculate the quad (using the eigen vectors of the
-        // 2D covariance) that is ultimately rasterized
+    static buildVertexShaderBase(dynamicMode = false, enableOptionalEffects = false, maxSphericalHarmonicsDegree = 0, customVars = '') {
         let vertexShaderSource = `
-            precision highp float;
-            #include <common>
+        precision highp float;
+        #include <common>
 
-            attribute uint splatIndex;
-            uniform highp usampler2D centersColorsTexture;
-            uniform highp sampler2D sphericalHarmonicsTexture;
-            uniform highp sampler2D sphericalHarmonicsTextureR;
-            uniform highp sampler2D sphericalHarmonicsTextureG;
-            uniform highp sampler2D sphericalHarmonicsTextureB;
+        attribute uint splatIndex;
+        uniform highp usampler2D centersColorsTexture;
+        uniform highp sampler2D sphericalHarmonicsTexture;
+        uniform highp sampler2D sphericalHarmonicsTextureR;
+        uniform highp sampler2D sphericalHarmonicsTextureG;
+        uniform highp sampler2D sphericalHarmonicsTextureB;
+    `;
+
+    if (enableOptionalEffects || dynamicMode) {
+        vertexShaderSource += `
+            uniform highp usampler2D sceneIndexesTexture;
+            uniform vec2 sceneIndexesTextureSize;
         `;
+    }
 
-        if (enableOptionalEffects || dynamicMode) {
+    if (enableOptionalEffects) {
+        vertexShaderSource += `
+            uniform float sceneOpacity[${Constants.MaxScenes}];
+            uniform int sceneVisibility[${Constants.MaxScenes}];
+        `;
+    }
+
+    if (dynamicMode) {
+        vertexShaderSource += `
+            uniform highp mat4 transforms[${Constants.MaxScenes}];
+        `;
+    }
+
+    vertexShaderSource += `
+        ${customVars}
+        uniform vec2 focal;
+        uniform float orthoZoom;
+        uniform int orthographicMode;
+        uniform int pointCloudModeEnabled;
+        uniform float inverseFocalAdjustment;
+        uniform vec2 viewport;
+        uniform vec2 basisViewport;
+        uniform vec2 centersColorsTextureSize;
+        uniform int sphericalHarmonicsDegree;
+        uniform vec2 sphericalHarmonicsTextureSize;
+        uniform int sphericalHarmonics8BitMode;
+        uniform int sphericalHarmonicsMultiTextureMode;
+        uniform float visibleRegionRadius;
+        uniform float visibleRegionFadeStartRadius;
+        uniform float firstRenderTime;
+        uniform float currentTime;
+        uniform int fadeInComplete;
+        uniform vec3 sceneCenter;
+        uniform float splatScale;
+
+        varying vec4 vColor;
+        varying vec2 vUv;
+        varying vec2 vPosition;
+
+        mat3 quaternionToRotationMatrix(float x, float y, float z, float w) {
+            float s = 1.0 / sqrt(w * w + x * x + y * y + z * z);
+        
+            return mat3(
+                1. - 2. * (y * y + z * z),
+                2. * (x * y + w * z),
+                2. * (x * z - w * y),
+                2. * (x * y - w * z),
+                1. - 2. * (x * x + z * z),
+                2. * (y * z + w * x),
+                2. * (x * z + w * y),
+                2. * (y * z - w * x),
+                1. - 2. * (x * x + y * y)
+            );
+        }
+
+        const float sqrt8 = sqrt(8.0);
+        const float minAlpha = 1.0 / 255.0;
+
+        const vec4 encodeNorm4 = vec4(1.0 / 255.0, 1.0 / 255.0, 1.0 / 255.0, 1.0 / 255.0);
+        const uvec4 mask4 = uvec4(uint(0x000000FF), uint(0x0000FF00), uint(0x00FF0000), uint(0xFF000000));
+        const uvec4 shift4 = uvec4(0, 8, 16, 24);
+        vec4 uintToRGBAVec (uint u) {
+           uvec4 urgba = mask4 & u;
+           urgba = urgba >> shift4;
+           vec4 rgba = vec4(urgba) * encodeNorm4;
+           return rgba;
+        }
+
+        vec2 getDataUV(in int stride, in int offset, in vec2 dimensions) {
+            vec2 samplerUV = vec2(0.0, 0.0);
+            float d = float(splatIndex * uint(stride) + uint(offset)) / dimensions.x;
+            samplerUV.y = float(floor(d)) / dimensions.y;
+            samplerUV.x = fract(d);
+            return samplerUV;
+        }
+
+        vec2 getDataUVF(in uint sIndex, in float stride, in uint offset, in vec2 dimensions) {
+            vec2 samplerUV = vec2(0.0, 0.0);
+            float d = float(uint(float(sIndex) * stride) + offset) / dimensions.x;
+            samplerUV.y = float(floor(d)) / dimensions.y;
+            samplerUV.x = fract(d);
+            return samplerUV;
+        }
+
+        const float SH_C1 = 0.4886025119029199f;
+        const float[5] SH_C2 = float[](1.0925484, -1.0925484, 0.3153916, -1.0925484, 0.5462742);
+
+        const float SphericalHarmonics8BitCompressionRange = ${Constants.SphericalHarmonics8BitCompressionRange.toFixed(1)};
+        const float SphericalHarmonics8BitCompressionHalfRange = SphericalHarmonics8BitCompressionRange / 2.0;
+        const vec3 vec8BitSHShift = vec3(SphericalHarmonics8BitCompressionHalfRange);
+
+        void main () {
+
+            uint oddOffset = splatIndex & uint(0x00000001);
+            uint doubleOddOffset = oddOffset * uint(2);
+            bool isEven = oddOffset == uint(0);
+            uint nearestEvenIndex = splatIndex - oddOffset;
+            float fOddOffset = float(oddOffset);
+
+            uvec4 sampledCenterColor = texture(centersColorsTexture, getDataUV(1, 0, centersColorsTextureSize));
+            vec3 splatCenter = uintBitsToFloat(uvec3(sampledCenterColor.gba));`;
+
+        if (dynamicMode || enableOptionalEffects) {
             vertexShaderSource += `
-                uniform highp usampler2D sceneIndexesTexture;
-                uniform vec2 sceneIndexesTextureSize;
+                uint sceneIndex = texture(sceneIndexesTexture, getDataUV(1, 0, sceneIndexesTextureSize)).r;
             `;
         }
 
         if (enableOptionalEffects) {
             vertexShaderSource += `
-                uniform float sceneOpacity[${Constants.MaxScenes}];
-                uniform int sceneVisibility[${Constants.MaxScenes}];
+                float splatOpacityFromScene = sceneOpacity[sceneIndex];
+                int sceneVisible = sceneVisibility[sceneIndex];
+                if (splatOpacityFromScene <= 0.01 || sceneVisible == 0) {
+                    gl_Position = vec4(0.0, 0.0, 2.0, 1.0);
+                    return;
+                }
             `;
         }
 
         if (dynamicMode) {
             vertexShaderSource += `
-                uniform highp mat4 transforms[${Constants.MaxScenes}];
-            `;
-        }
-
-        if (splatRenderMode === SplatRenderMode.ThreeD) {
-            vertexShaderSource += `
-                uniform vec2 covariancesTextureSize;
-                uniform highp sampler2D covariancesTexture;
+                mat4 transform = transforms[sceneIndex];
+                mat4 transformModelViewMatrix = modelViewMatrix * transform;
             `;
         } else {
-            vertexShaderSource += `
-                uniform vec2 scaleRotationsTextureSize;
-                uniform highp sampler2D scaleRotationsTexture;
-                varying mat3 vT;
-                varying vec2 vQuadCenter;
-                varying vec2 vFragCoord;
-            `;
+            vertexShaderSource += `mat4 transformModelViewMatrix = modelViewMatrix;`;
         }
 
         vertexShaderSource += `
-            uniform vec2 focal;
-            uniform float orthoZoom;
-            uniform int orthographicMode;
-            uniform int pointCloudModeEnabled;
-            uniform float inverseFocalAdjustment;
-            uniform vec2 viewport;
-            uniform vec2 basisViewport;
-            uniform vec2 centersColorsTextureSize;
-            uniform int sphericalHarmonicsDegree;
-            uniform vec2 sphericalHarmonicsTextureSize;
-            uniform int sphericalHarmonics8BitMode;
-            uniform int sphericalHarmonicsMultiTextureMode;
-            uniform float visibleRegionRadius;
-            uniform float visibleRegionFadeStartRadius;
-            uniform float firstRenderTime;
-            uniform float currentTime;
-            uniform int fadeInComplete;
-            uniform vec3 sceneCenter;
-            uniform float splatScale;
+            vec4 viewCenter = transformModelViewMatrix * vec4(splatCenter, 1.0);
 
-            varying vec4 vColor;
-            varying vec2 vUv;
-            varying vec2 vPosition;
+            vec4 clipCenter = projectionMatrix * viewCenter;
 
-            mat3 quaternionToRotationMatrix(float x, float y, float z, float w) {
-                float s = 1.0 / sqrt(w * w + x * x + y * y + z * z);
-            
-                return mat3(
-                    1. - 2. * (y * y + z * z),
-                    2. * (x * y + w * z),
-                    2. * (x * z - w * y),
-                    2. * (x * y - w * z),
-                    1. - 2. * (x * x + z * z),
-                    2. * (y * z + w * x),
-                    2. * (x * z + w * y),
-                    2. * (y * z - w * x),
-                    1. - 2. * (x * x + y * y)
-                );
+            float clip = 1.2 * clipCenter.w;
+            if (clipCenter.z < -clip || clipCenter.x < -clip || clipCenter.x > clip || clipCenter.y < -clip || clipCenter.y > clip) {
+                gl_Position = vec4(0.0, 0.0, 2.0, 1.0);
+                return;
             }
 
-            const float sqrt8 = sqrt(8.0);
-            const float minAlpha = 1.0 / 255.0;
+            vec3 ndcCenter = clipCenter.xyz / clipCenter.w;
 
-            const vec4 encodeNorm4 = vec4(1.0 / 255.0, 1.0 / 255.0, 1.0 / 255.0, 1.0 / 255.0);
-            const uvec4 mask4 = uvec4(uint(0x000000FF), uint(0x0000FF00), uint(0x00FF0000), uint(0xFF000000));
-            const uvec4 shift4 = uvec4(0, 8, 16, 24);
-            vec4 uintToRGBAVec (uint u) {
-               uvec4 urgba = mask4 & u;
-               urgba = urgba >> shift4;
-               vec4 rgba = vec4(urgba) * encodeNorm4;
-               return rgba;
-            }
+            vPosition = position.xy;
+            vColor = uintToRGBAVec(sampledCenterColor.r);
+        `;
 
-            vec2 getDataUV(in int stride, in int offset, in vec2 dimensions) {
-                vec2 samplerUV = vec2(0.0, 0.0);
-                float d = float(splatIndex * uint(stride) + uint(offset)) / dimensions.x;
-                samplerUV.y = float(floor(d)) / dimensions.y;
-                samplerUV.x = fract(d);
-                return samplerUV;
-            }
+        if (maxSphericalHarmonicsDegree >= 1) {
 
-            vec2 getDataUVF(in uint sIndex, in float stride, in uint offset, in vec2 dimensions) {
-                vec2 samplerUV = vec2(0.0, 0.0);
-                float d = float(uint(float(sIndex) * stride) + offset) / dimensions.x;
-                samplerUV.y = float(floor(d)) / dimensions.y;
-                samplerUV.x = fract(d);
-                return samplerUV;
-            }
+            vertexShaderSource += `   
+            if (sphericalHarmonicsDegree >= 1) {
+            `;
 
-            const float SH_C1 = 0.4886025119029199f;
-            const float[5] SH_C2 = float[](1.0925484, -1.0925484, 0.3153916, -1.0925484, 0.5462742);
-
-            const float SphericalHarmonics8BitCompressionRange = ${Constants.SphericalHarmonics8BitCompressionRange.toFixed(1)};
-            const float SphericalHarmonics8BitCompressionHalfRange = SphericalHarmonics8BitCompressionRange / 2.0;
-            const vec3 vec8BitSHShift = vec3(SphericalHarmonics8BitCompressionHalfRange);
-
-            void main () {
-
-                uint oddOffset = splatIndex & uint(0x00000001);
-                uint doubleOddOffset = oddOffset * uint(2);
-                bool isEven = oddOffset == uint(0);
-                uint nearestEvenIndex = splatIndex - oddOffset;
-                float fOddOffset = float(oddOffset);
-
-                uvec4 sampledCenterColor = texture(centersColorsTexture, getDataUV(1, 0, centersColorsTextureSize));
-                vec3 splatCenter = uintBitsToFloat(uvec3(sampledCenterColor.gba));`;
-
-            if (dynamicMode || enableOptionalEffects) {
+            if (dynamicMode) {
                 vertexShaderSource += `
-                    uint sceneIndex = texture(sceneIndexesTexture, getDataUV(1, 0, sceneIndexesTextureSize)).r;
+                    mat4 mTransform = modelMatrix * transform;
+                    vec3 worldViewDir = normalize(splatCenter - vec3(inverse(mTransform) * vec4(cameraPosition, 1.0)));
+                `;
+            } else {
+                vertexShaderSource += `
+                    vec3 worldViewDir = normalize(splatCenter - cameraPosition);
                 `;
             }
 
-            if (enableOptionalEffects) {
+            vertexShaderSource += `
+                vec3 sh1;
+                vec3 sh2;
+                vec3 sh3;
+            `;
+
+            if (maxSphericalHarmonicsDegree >= 2) {
                 vertexShaderSource += `
-                    float splatOpacityFromScene = sceneOpacity[sceneIndex];
-                    int sceneVisible = sceneVisibility[sceneIndex];
-                    if (splatOpacityFromScene <= 0.01 || sceneVisible == 0) {
-                        gl_Position = vec4(0.0, 0.0, 2.0, 1.0);
-                        return;
+                    vec4 sampledSH0123;
+                    vec4 sampledSH4567;
+                    vec4 sampledSH891011;
+
+                    vec4 sampledSH0123R;
+                    vec4 sampledSH0123G;
+                    vec4 sampledSH0123B;
+                    
+                    if (sphericalHarmonicsMultiTextureMode == 0) {
+                        sampledSH0123 = texture(sphericalHarmonicsTexture, getDataUV(6, 0, sphericalHarmonicsTextureSize));
+                        sampledSH4567 = texture(sphericalHarmonicsTexture, getDataUV(6, 1, sphericalHarmonicsTextureSize));
+                        sampledSH891011 = texture(sphericalHarmonicsTexture, getDataUV(6, 2, sphericalHarmonicsTextureSize));
+                        sh1 = sampledSH0123.rgb;
+                        sh2 = vec3(sampledSH0123.a, sampledSH4567.rg);
+                        sh3 = vec3(sampledSH4567.ba, sampledSH891011.r);
+                    } else {
+                        sampledSH0123R = texture(sphericalHarmonicsTextureR, getDataUV(2, 0, sphericalHarmonicsTextureSize));
+                        sampledSH0123G = texture(sphericalHarmonicsTextureG, getDataUV(2, 0, sphericalHarmonicsTextureSize));
+                        sampledSH0123B = texture(sphericalHarmonicsTextureB, getDataUV(2, 0, sphericalHarmonicsTextureSize));
+                        sh1 = vec3(sampledSH0123R.rgb);
+                        sh2 = vec3(sampledSH0123G.rgb);
+                        sh3 = vec3(sampledSH0123B.rgb);
+                    }
+                `;
+            } else {
+                vertexShaderSource += `
+                    if (sphericalHarmonicsMultiTextureMode == 0) {
+                        vec2 shUV = getDataUVF(nearestEvenIndex, 2.5, doubleOddOffset, sphericalHarmonicsTextureSize);
+                        vec4 sampledSH0123 = texture(sphericalHarmonicsTexture, shUV);
+                        shUV = getDataUVF(nearestEvenIndex, 2.5, doubleOddOffset + uint(1), sphericalHarmonicsTextureSize);
+                        vec4 sampledSH4567 = texture(sphericalHarmonicsTexture, shUV);
+                        shUV = getDataUVF(nearestEvenIndex, 2.5, doubleOddOffset + uint(2), sphericalHarmonicsTextureSize);
+                        vec4 sampledSH891011 = texture(sphericalHarmonicsTexture, shUV);
+                        sh1 = vec3(sampledSH0123.rgb) * (1.0 - fOddOffset) + vec3(sampledSH0123.ba, sampledSH4567.r) * fOddOffset;
+                        sh2 = vec3(sampledSH0123.a, sampledSH4567.rg) * (1.0 - fOddOffset) + vec3(sampledSH4567.gba) * fOddOffset;
+                        sh3 = vec3(sampledSH4567.ba, sampledSH891011.r) * (1.0 - fOddOffset) + vec3(sampledSH891011.rgb) * fOddOffset;
+                    } else {
+                        vec2 sampledSH01R = texture(sphericalHarmonicsTextureR, getDataUV(2, 0, sphericalHarmonicsTextureSize)).rg;
+                        vec2 sampledSH23R = texture(sphericalHarmonicsTextureR, getDataUV(2, 1, sphericalHarmonicsTextureSize)).rg;
+                        vec2 sampledSH01G = texture(sphericalHarmonicsTextureG, getDataUV(2, 0, sphericalHarmonicsTextureSize)).rg;
+                        vec2 sampledSH23G = texture(sphericalHarmonicsTextureG, getDataUV(2, 1, sphericalHarmonicsTextureSize)).rg;
+                        vec2 sampledSH01B = texture(sphericalHarmonicsTextureB, getDataUV(2, 0, sphericalHarmonicsTextureSize)).rg;
+                        vec2 sampledSH23B = texture(sphericalHarmonicsTextureB, getDataUV(2, 1, sphericalHarmonicsTextureSize)).rg;
+                        sh1 = vec3(sampledSH01R.rg, sampledSH23R.r);
+                        sh2 = vec3(sampledSH01G.rg, sampledSH23G.r);
+                        sh3 = vec3(sampledSH01B.rg, sampledSH23B.r);
                     }
                 `;
             }
 
-            if (dynamicMode) {
+            vertexShaderSource += `
+                    if (sphericalHarmonics8BitMode == 1) {
+                        sh1 = sh1 * SphericalHarmonics8BitCompressionRange - vec8BitSHShift;
+                        sh2 = sh2 * SphericalHarmonics8BitCompressionRange - vec8BitSHShift;
+                        sh3 = sh3 * SphericalHarmonics8BitCompressionRange - vec8BitSHShift;
+                    }
+                    float x = worldViewDir.x;
+                    float y = worldViewDir.y;
+                    float z = worldViewDir.z;
+                    vColor.rgb += SH_C1 * (-sh1 * y + sh2 * z - sh3 * x);
+            `;
+
+            if (maxSphericalHarmonicsDegree >= 2) {
+
                 vertexShaderSource += `
-                    mat4 transform = transforms[sceneIndex];
-                    mat4 transformModelViewMatrix = modelViewMatrix * transform;
+                    if (sphericalHarmonicsDegree >= 2) {
+                        float xx = x * x;
+                        float yy = y * y;
+                        float zz = z * z;
+                        float xy = x * y;
+                        float yz = y * z;
+                        float xz = x * z;
+
+                        vec3 sh4;
+                        vec3 sh5;
+                        vec3 sh6;
+                        vec3 sh7;
+                        vec3 sh8;
+
+                        if (sphericalHarmonicsMultiTextureMode == 0) {
+                            vec4 sampledSH12131415 = texture(sphericalHarmonicsTexture, getDataUV(6, 3, sphericalHarmonicsTextureSize));
+                            vec4 sampledSH16171819 = texture(sphericalHarmonicsTexture, getDataUV(6, 4, sphericalHarmonicsTextureSize));
+                            vec4 sampledSH20212223 = texture(sphericalHarmonicsTexture, getDataUV(6, 5, sphericalHarmonicsTextureSize));
+                            sh4 = sampledSH891011.gba;
+                            sh5 = sampledSH12131415.rgb;
+                            sh6 = vec3(sampledSH12131415.a, sampledSH16171819.rg);
+                            sh7 = vec3(sampledSH16171819.ba, sampledSH20212223.r);
+                            sh8 = sampledSH20212223.gba;
+                        } else {
+                            vec4 sampledSH4567R = texture(sphericalHarmonicsTextureR, getDataUV(2, 1, sphericalHarmonicsTextureSize));
+                            vec4 sampledSH4567G = texture(sphericalHarmonicsTextureG, getDataUV(2, 1, sphericalHarmonicsTextureSize));
+                            vec4 sampledSH4567B = texture(sphericalHarmonicsTextureB, getDataUV(2, 1, sphericalHarmonicsTextureSize));
+                            sh4 = vec3(sampledSH0123R.a, sampledSH4567R.rg);
+                            sh5 = vec3(sampledSH4567R.ba, sampledSH0123G.a);
+                            sh6 = vec3(sampledSH4567G.rgb);
+                            sh7 = vec3(sampledSH4567G.a, sampledSH0123B.a, sampledSH4567B.r);
+                            sh8 = vec3(sampledSH4567B.gba);
+                        }
+
+                        if (sphericalHarmonics8BitMode == 1) {
+                            sh4 = sh4 * SphericalHarmonics8BitCompressionRange - vec8BitSHShift;
+                            sh5 = sh5 * SphericalHarmonics8BitCompressionRange - vec8BitSHShift;
+                            sh6 = sh6 * SphericalHarmonics8BitCompressionRange - vec8BitSHShift;
+                            sh7 = sh7 * SphericalHarmonics8BitCompressionRange - vec8BitSHShift;
+                            sh8 = sh8 * SphericalHarmonics8BitCompressionRange - vec8BitSHShift;
+                        }
+
+                        vColor.rgb +=
+                            (SH_C2[0] * xy) * sh4 +
+                            (SH_C2[1] * yz) * sh5 +
+                            (SH_C2[2] * (2.0 * zz - xx - yy)) * sh6 +
+                            (SH_C2[3] * xz) * sh7 +
+                            (SH_C2[4] * (xx - yy)) * sh8;
+                    }
                 `;
-            } else {
-                vertexShaderSource += `mat4 transformModelViewMatrix = modelViewMatrix;`;
             }
 
             vertexShaderSource += `
-                vec4 viewCenter = transformModelViewMatrix * vec4(splatCenter, 1.0);
+           
+                vColor.rgb = clamp(vColor.rgb, vec3(0.), vec3(1.));
 
-                vec4 clipCenter = projectionMatrix * viewCenter;
-
-                float clip = 1.2 * clipCenter.w;
-                if (clipCenter.z < -clip || clipCenter.x < -clip || clipCenter.x > clip || clipCenter.y < -clip || clipCenter.y > clip) {
-                    gl_Position = vec4(0.0, 0.0, 2.0, 1.0);
-                    return;
-                }
-
-                vec3 ndcCenter = clipCenter.xyz / clipCenter.w;
-
-                vPosition = position.xy;
-                vColor = uintToRGBAVec(sampledCenterColor.r);
-            `;
-
-            if (maxSphericalHarmonicsDegree >= 1) {
-
-                vertexShaderSource += `   
-                if (sphericalHarmonicsDegree >= 1) {
-                `;
-
-                if (dynamicMode) {
-                    vertexShaderSource += `
-                        mat4 mTransform = modelMatrix * transform;
-                        vec3 worldViewDir = normalize(splatCenter - vec3(inverse(mTransform) * vec4(cameraPosition, 1.0)));
-                    `;
-                } else {
-                    vertexShaderSource += `
-                        vec3 worldViewDir = normalize(splatCenter - cameraPosition);
-                    `;
-                }
-
-                vertexShaderSource += `
-                    vec3 sh1;
-                    vec3 sh2;
-                    vec3 sh3;
-                `;
-
-                if (maxSphericalHarmonicsDegree >= 2) {
-                    vertexShaderSource += `
-                        vec4 sampledSH0123;
-                        vec4 sampledSH4567;
-                        vec4 sampledSH891011;
-
-                        vec4 sampledSH0123R;
-                        vec4 sampledSH0123G;
-                        vec4 sampledSH0123B;
-                        
-                        if (sphericalHarmonicsMultiTextureMode == 0) {
-                            sampledSH0123 = texture(sphericalHarmonicsTexture, getDataUV(6, 0, sphericalHarmonicsTextureSize));
-                            sampledSH4567 = texture(sphericalHarmonicsTexture, getDataUV(6, 1, sphericalHarmonicsTextureSize));
-                            sampledSH891011 = texture(sphericalHarmonicsTexture, getDataUV(6, 2, sphericalHarmonicsTextureSize));
-                            sh1 = sampledSH0123.rgb;
-                            sh2 = vec3(sampledSH0123.a, sampledSH4567.rg);
-                            sh3 = vec3(sampledSH4567.ba, sampledSH891011.r);
-                        } else {
-                            sampledSH0123R = texture(sphericalHarmonicsTextureR, getDataUV(2, 0, sphericalHarmonicsTextureSize));
-                            sampledSH0123G = texture(sphericalHarmonicsTextureG, getDataUV(2, 0, sphericalHarmonicsTextureSize));
-                            sampledSH0123B = texture(sphericalHarmonicsTextureB, getDataUV(2, 0, sphericalHarmonicsTextureSize));
-                            sh1 = vec3(sampledSH0123R.rgb);
-                            sh2 = vec3(sampledSH0123G.rgb);
-                            sh3 = vec3(sampledSH0123B.rgb);
-                        }
-                    `;
-                } else {
-                    vertexShaderSource += `
-                        if (sphericalHarmonicsMultiTextureMode == 0) {
-                            vec2 shUV = getDataUVF(nearestEvenIndex, 2.5, doubleOddOffset, sphericalHarmonicsTextureSize);
-                            vec4 sampledSH0123 = texture(sphericalHarmonicsTexture, shUV);
-                            shUV = getDataUVF(nearestEvenIndex, 2.5, doubleOddOffset + uint(1), sphericalHarmonicsTextureSize);
-                            vec4 sampledSH4567 = texture(sphericalHarmonicsTexture, shUV);
-                            shUV = getDataUVF(nearestEvenIndex, 2.5, doubleOddOffset + uint(2), sphericalHarmonicsTextureSize);
-                            vec4 sampledSH891011 = texture(sphericalHarmonicsTexture, shUV);
-                            sh1 = vec3(sampledSH0123.rgb) * (1.0 - fOddOffset) + vec3(sampledSH0123.ba, sampledSH4567.r) * fOddOffset;
-                            sh2 = vec3(sampledSH0123.a, sampledSH4567.rg) * (1.0 - fOddOffset) + vec3(sampledSH4567.gba) * fOddOffset;
-                            sh3 = vec3(sampledSH4567.ba, sampledSH891011.r) * (1.0 - fOddOffset) + vec3(sampledSH891011.rgb) * fOddOffset;
-                        } else {
-                            vec2 sampledSH01R = texture(sphericalHarmonicsTextureR, getDataUV(2, 0, sphericalHarmonicsTextureSize)).rg;
-                            vec2 sampledSH23R = texture(sphericalHarmonicsTextureR, getDataUV(2, 1, sphericalHarmonicsTextureSize)).rg;
-                            vec2 sampledSH01G = texture(sphericalHarmonicsTextureG, getDataUV(2, 0, sphericalHarmonicsTextureSize)).rg;
-                            vec2 sampledSH23G = texture(sphericalHarmonicsTextureG, getDataUV(2, 1, sphericalHarmonicsTextureSize)).rg;
-                            vec2 sampledSH01B = texture(sphericalHarmonicsTextureB, getDataUV(2, 0, sphericalHarmonicsTextureSize)).rg;
-                            vec2 sampledSH23B = texture(sphericalHarmonicsTextureB, getDataUV(2, 1, sphericalHarmonicsTextureSize)).rg;
-                            sh1 = vec3(sampledSH01R.rg, sampledSH23R.r);
-                            sh2 = vec3(sampledSH01G.rg, sampledSH23G.r);
-                            sh3 = vec3(sampledSH01B.rg, sampledSH23B.r);
-                        }
-                    `;
-                }
-
-                vertexShaderSource += `
-                        if (sphericalHarmonics8BitMode == 1) {
-                            sh1 = sh1 * SphericalHarmonics8BitCompressionRange - vec8BitSHShift;
-                            sh2 = sh2 * SphericalHarmonics8BitCompressionRange - vec8BitSHShift;
-                            sh3 = sh3 * SphericalHarmonics8BitCompressionRange - vec8BitSHShift;
-                        }
-                        float x = worldViewDir.x;
-                        float y = worldViewDir.y;
-                        float z = worldViewDir.z;
-                        vColor.rgb += SH_C1 * (-sh1 * y + sh2 * z - sh3 * x);
-                `;
-
-                if (maxSphericalHarmonicsDegree >= 2) {
-
-                    vertexShaderSource += `
-                        if (sphericalHarmonicsDegree >= 2) {
-                            float xx = x * x;
-                            float yy = y * y;
-                            float zz = z * z;
-                            float xy = x * y;
-                            float yz = y * z;
-                            float xz = x * z;
-
-                            vec3 sh4;
-                            vec3 sh5;
-                            vec3 sh6;
-                            vec3 sh7;
-                            vec3 sh8;
-
-                            if (sphericalHarmonicsMultiTextureMode == 0) {
-                                vec4 sampledSH12131415 = texture(sphericalHarmonicsTexture, getDataUV(6, 3, sphericalHarmonicsTextureSize));
-                                vec4 sampledSH16171819 = texture(sphericalHarmonicsTexture, getDataUV(6, 4, sphericalHarmonicsTextureSize));
-                                vec4 sampledSH20212223 = texture(sphericalHarmonicsTexture, getDataUV(6, 5, sphericalHarmonicsTextureSize));
-                                sh4 = sampledSH891011.gba;
-                                sh5 = sampledSH12131415.rgb;
-                                sh6 = vec3(sampledSH12131415.a, sampledSH16171819.rg);
-                                sh7 = vec3(sampledSH16171819.ba, sampledSH20212223.r);
-                                sh8 = sampledSH20212223.gba;
-                            } else {
-                                vec4 sampledSH4567R = texture(sphericalHarmonicsTextureR, getDataUV(2, 1, sphericalHarmonicsTextureSize));
-                                vec4 sampledSH4567G = texture(sphericalHarmonicsTextureG, getDataUV(2, 1, sphericalHarmonicsTextureSize));
-                                vec4 sampledSH4567B = texture(sphericalHarmonicsTextureB, getDataUV(2, 1, sphericalHarmonicsTextureSize));
-                                sh4 = vec3(sampledSH0123R.a, sampledSH4567R.rg);
-                                sh5 = vec3(sampledSH4567R.ba, sampledSH0123G.a);
-                                sh6 = vec3(sampledSH4567G.rgb);
-                                sh7 = vec3(sampledSH4567G.a, sampledSH0123B.a, sampledSH4567B.r);
-                                sh8 = vec3(sampledSH4567B.gba);
-                            }
-
-                            if (sphericalHarmonics8BitMode == 1) {
-                                sh4 = sh4 * SphericalHarmonics8BitCompressionRange - vec8BitSHShift;
-                                sh5 = sh5 * SphericalHarmonics8BitCompressionRange - vec8BitSHShift;
-                                sh6 = sh6 * SphericalHarmonics8BitCompressionRange - vec8BitSHShift;
-                                sh7 = sh7 * SphericalHarmonics8BitCompressionRange - vec8BitSHShift;
-                                sh8 = sh8 * SphericalHarmonics8BitCompressionRange - vec8BitSHShift;
-                            }
-
-                            vColor.rgb +=
-                                (SH_C2[0] * xy) * sh4 +
-                                (SH_C2[1] * yz) * sh5 +
-                                (SH_C2[2] * (2.0 * zz - xx - yy)) * sh6 +
-                                (SH_C2[3] * xz) * sh7 +
-                                (SH_C2[4] * (xx - yy)) * sh8;
-                        }
-                    `;
-                }
-
-                vertexShaderSource += `
-               
-                    vColor.rgb = clamp(vColor.rgb, vec3(0.), vec3(1.));
-
-                }
-
-                `;
             }
 
-        vertexShaderSource += SplatMaterial.buildSplatProjectionSection(splatRenderMode, antialiased,
-                                                                        enableOptionalEffects, maxScreenSpaceSplatSize);
-
-        let fragmentShaderSource = `
-            precision highp float;
-            #include <common>
- 
-            uniform vec3 debugColor;
-
-            varying vec4 vColor;
-            varying vec2 vUv;
-            varying vec2 vPosition;
-        `;
-
-        if (splatRenderMode === SplatRenderMode.TwoD) {
-            fragmentShaderSource += `
-                varying mat3 vT;
-                varying vec2 vQuadCenter;
-                varying vec2 vFragCoord;
             `;
         }
 
-        fragmentShaderSource += `
-            void main () {
-        `;
+        return vertexShaderSource;
+    }
 
-        if (splatRenderMode === SplatRenderMode.ThreeD) {
-            fragmentShaderSource += `
-                // Compute the positional squared distance from the center of the splat to the current fragment.
-                float A = dot(vPosition, vPosition);
-                // Since the positional data in vPosition has been scaled by sqrt(8), the squared result will be
-                // scaled by a factor of 8. If the squared result is larger than 8, it means it is outside the ellipse
-                // defined by the rectangle formed by vPosition. It also means it's farther
-                // away than sqrt(8) standard deviations from the mean.
-                if (A > 8.0) discard;
-                vec3 color = vColor.rgb;
+    static getVertexShaderFadeIn() {
+        return `
+            if (fadeInComplete == 0) {
+                float opacityAdjust = 1.0;
+                float centerDist = length(splatCenter - sceneCenter);
+                float renderTime = max(currentTime - firstRenderTime, 0.0);
 
-                // Since the rendered splat is scaled by sqrt(8), the inverse covariance matrix that is part of
-                // the gaussian formula becomes the identity matrix. We're then left with (X - mean) * (X - mean),
-                // and since 'mean' is zero, we have X * X, which is the same as A:
-                float opacity = exp(-0.5 * A) * vColor.a;
-
-                gl_FragColor = vec4(color.rgb, opacity);
-            `;
-        } else {
-            /*
-                const float2 xy = collected_xy[j];
-                const float3 Tu = collected_Tu[j];
-                const float3 Tv = collected_Tv[j];
-                const float3 Tw = collected_Tw[j];
-                float3 k = pix.x * Tw - Tu;
-                float3 l = pix.y * Tw - Tv;
-                float3 p = cross(k, l);
-                if (p.z == 0.0) continue;
-                float2 s = {p.x / p.z, p.y / p.z};
-                float rho3d = (s.x * s.x + s.y * s.y);
-                float2 d = {xy.x - pixf.x, xy.y - pixf.y};
-                float rho2d = FilterInvSquare * (d.x * d.x + d.y * d.y);
-
-                // compute intersection and depth
-                float rho = min(rho3d, rho2d);
-                float depth = (rho3d <= rho2d) ? (s.x * Tw.x + s.y * Tw.y) + Tw.z : Tw.z;
-                if (depth < near_n) continue;
-                float4 nor_o = collected_normal_opacity[j];
-                float normal[3] = {nor_o.x, nor_o.y, nor_o.z};
-                float opa = nor_o.w;
-
-                float power = -0.5f * rho;
-                if (power > 0.0f)
-                    continue;
-
-                // Eq. (2) from 3D Gaussian splatting paper.
-                // Obtain alpha by multiplying with Gaussian opacity
-                // and its exponential falloff from mean.
-                // Avoid numerical instabilities (see paper appendix).
-                float alpha = min(0.99f, opa * exp(power));
-                if (alpha < 1.0f / 255.0f)
-                    continue;
-                float test_T = T * (1 - alpha);
-                if (test_T < 0.0001f)
-                {
-                    done = true;
-                    continue;
-                }
-
-                float w = alpha * T;
-            */
-            fragmentShaderSource += `
-
-                const float FilterInvSquare = 2.0;
-                const float near_n = 0.2;
-                const float T = 1.0;
-
-                vec2 xy = vQuadCenter;
-                vec3 Tu = vT[0];
-                vec3 Tv = vT[1];
-                vec3 Tw = vT[2];
-                vec3 k = vFragCoord.x * Tw - Tu;
-                vec3 l = vFragCoord.y * Tw - Tv;
-                vec3 p = cross(k, l);
-                if (p.z == 0.0) discard;
-                vec2 s = vec2(p.x / p.z, p.y / p.z);
-                float rho3d = (s.x * s.x + s.y * s.y); 
-                vec2 d = vec2(xy.x - vFragCoord.x, xy.y - vFragCoord.y);
-                float rho2d = FilterInvSquare * (d.x * d.x + d.y * d.y); 
-
-                // compute intersection and depth
-                float rho = min(rho3d, rho2d);
-                float depth = (rho3d <= rho2d) ? (s.x * Tw.x + s.y * Tw.y) + Tw.z : Tw.z; 
-                if (depth < near_n) discard;
-                //  vec4 nor_o = collected_normal_opacity[j];
-                //  float normal[3] = {nor_o.x, nor_o.y, nor_o.z};
-                float opa = vColor.a;
-
-                float power = -0.5f * rho;
-                if (power > 0.0f) discard;
-
-                // Eq. (2) from 3D Gaussian splatting paper.
-                // Obtain alpha by multiplying with Gaussian opacity
-                // and its exponential falloff from mean.
-                // Avoid numerical instabilities (see paper appendix). 
-                float alpha = min(0.99f, opa * exp(power));
-                if (alpha < 1.0f / 255.0f) discard;
-                float test_T = T * (1.0 - alpha);
-                if (test_T < 0.0001)discard;
-
-                float w = alpha * T;
-                gl_FragColor = vec4(vColor.rgb, w);
-            `;
-        }
-
-        fragmentShaderSource += `
+                float fadeDistance = 0.75;
+                float distanceLoadFadeInFactor = step(visibleRegionFadeStartRadius, centerDist);
+                distanceLoadFadeInFactor = (1.0 - distanceLoadFadeInFactor) +
+                                        (1.0 - clamp((centerDist - visibleRegionFadeStartRadius) / fadeDistance, 0.0, 1.0)) *
+                                        distanceLoadFadeInFactor;
+                opacityAdjust *= distanceLoadFadeInFactor;
+                vColor.a *= opacityAdjust;
             }
         `;
+    }
+
+    static getUniforms(dynamicMode = false, enableOptionalEffects = false, maxSphericalHarmonicsDegree = 0,
+                       splatScale = 1.0, pointCloudModeEnabled = false) {
 
         const uniforms = {
             'sceneCenter': {
@@ -590,26 +446,6 @@ export class SplatMaterial {
             }
         };
 
-        if (splatRenderMode === SplatRenderMode.ThreeD) {
-            uniforms['covariancesTexture'] = {
-                'type': 't',
-                'value': null
-            };
-            uniforms['covariancesTextureSize'] = {
-                'type': 'v2',
-                'value': new THREE.Vector2(1024, 1024)
-            };
-        } else {
-            uniforms['scaleRotationsTexture'] = {
-                'type': 't',
-                'value': null
-            };
-            uniforms['scaleRotationsTextureSize'] = {
-                'type': 'v2',
-                'value': new THREE.Vector2(1024, 1024)
-            };
-        }
-
         if (dynamicMode || enableOptionalEffects) {
             uniforms['sceneIndexesTexture'] = {
                 'type': 't',
@@ -652,346 +488,7 @@ export class SplatMaterial {
             };
         }
 
-        const material = new THREE.ShaderMaterial({
-            uniforms: uniforms,
-            vertexShader: vertexShaderSource,
-            fragmentShader: fragmentShaderSource,
-            transparent: true,
-            alphaTest: 1.0,
-            blending: THREE.NormalBlending,
-            depthTest: true,
-            depthWrite: false,
-            side: THREE.DoubleSide
-        });
-
-        return material;
+        return uniforms;
     }
 
-    static buildSplatProjectionSection(splatRenderMode, antialiased, enableOptionalEffects, maxScreenSpaceSplatSize) {
-
-        let vertexShaderSource = '';
-
-        if (splatRenderMode === SplatRenderMode.ThreeD) {
-
-            vertexShaderSource += `
-
-                vec4 sampledCovarianceA = texture(covariancesTexture, getDataUVF(nearestEvenIndex, 1.5, oddOffset,
-                                                                                 covariancesTextureSize));
-                vec4 sampledCovarianceB = texture(covariancesTexture, getDataUVF(nearestEvenIndex, 1.5, oddOffset + uint(1),
-                                                                                 covariancesTextureSize));
-
-                vec3 cov3D_M11_M12_M13 = vec3(sampledCovarianceA.rgb) * (1.0 - fOddOffset) +
-                                         vec3(sampledCovarianceA.ba, sampledCovarianceB.r) * fOddOffset;
-                vec3 cov3D_M22_M23_M33 = vec3(sampledCovarianceA.a, sampledCovarianceB.rg) * (1.0 - fOddOffset) +
-                                         vec3(sampledCovarianceB.gba) * fOddOffset;
-
-                // Construct the 3D covariance matrix
-                mat3 Vrk = mat3(
-                    cov3D_M11_M12_M13.x, cov3D_M11_M12_M13.y, cov3D_M11_M12_M13.z,
-                    cov3D_M11_M12_M13.y, cov3D_M22_M23_M33.x, cov3D_M22_M23_M33.y,
-                    cov3D_M11_M12_M13.z, cov3D_M22_M23_M33.y, cov3D_M22_M23_M33.z
-                );
-
-                mat3 J;
-                if (orthographicMode == 1) {
-                    // Since the projection is linear, we don't need an approximation
-                    J = transpose(mat3(orthoZoom, 0.0, 0.0,
-                                       0.0, orthoZoom, 0.0,
-                                       0.0, 0.0, 0.0));
-                } else {
-                    // Construct the Jacobian of the affine approximation of the projection matrix. It will be used to transform the
-                    // 3D covariance matrix instead of using the actual projection matrix because that transformation would
-                    // require a non-linear component (perspective division) which would yield a non-gaussian result.
-                    float s = 1.0 / (viewCenter.z * viewCenter.z);
-                    J = mat3(
-                        focal.x / viewCenter.z, 0., -(focal.x * viewCenter.x) * s,
-                        0., focal.y / viewCenter.z, -(focal.y * viewCenter.y) * s,
-                        0., 0., 0.
-                    );
-                }
-
-                // Concatenate the projection approximation with the model-view transformation
-                mat3 W = transpose(mat3(transformModelViewMatrix));
-                mat3 T = W * J;
-
-                // Transform the 3D covariance matrix (Vrk) to compute the 2D covariance matrix
-                mat3 cov2Dm = transpose(T) * Vrk * T;
-                `;
-
-            if (antialiased) {
-                vertexShaderSource += `
-                    float detOrig = cov2Dm[0][0] * cov2Dm[1][1] - cov2Dm[0][1] * cov2Dm[0][1];
-                    cov2Dm[0][0] += 0.3;
-                    cov2Dm[1][1] += 0.3;
-                    float detBlur = cov2Dm[0][0] * cov2Dm[1][1] - cov2Dm[0][1] * cov2Dm[0][1];
-                    vColor.a *= sqrt(max(detOrig / detBlur, 0.0));
-                    if (vColor.a < minAlpha) return;
-                `;
-            } else {
-                vertexShaderSource += `
-                    cov2Dm[0][0] += 0.3;
-                    cov2Dm[1][1] += 0.3;
-                `;
-            }
-
-            vertexShaderSource += `
-
-                // We are interested in the upper-left 2x2 portion of the projected 3D covariance matrix because
-                // we only care about the X and Y values. We want the X-diagonal, cov2Dm[0][0],
-                // the Y-diagonal, cov2Dm[1][1], and the correlation between the two cov2Dm[0][1]. We don't
-                // need cov2Dm[1][0] because it is a symetric matrix.
-                vec3 cov2Dv = vec3(cov2Dm[0][0], cov2Dm[0][1], cov2Dm[1][1]);
-
-                // We now need to solve for the eigen-values and eigen vectors of the 2D covariance matrix
-                // so that we can determine the 2D basis for the splat. This is done using the method described
-                // here: https://people.math.harvard.edu/~knill/teaching/math21b2004/exhibits/2dmatrices/index.html
-                // After calculating the eigen-values and eigen-vectors, we calculate the basis for rendering the splat
-                // by normalizing the eigen-vectors and then multiplying them by (sqrt(8) * sqrt(eigen-value)), which is
-                // equal to scaling them by sqrt(8) standard deviations.
-                //
-                // This is a different approach than in the original work at INRIA. In that work they compute the
-                // max extents of the projected splat in screen space to form a screen-space aligned bounding rectangle
-                // which forms the geometry that is actually rasterized. The dimensions of that bounding box are 3.0
-                // times the square root of the maximum eigen-value, or 3 standard deviations. They then use the inverse
-                // 2D covariance matrix (called 'conic') in the CUDA rendering thread to determine fragment opacity by
-                // calculating the full gaussian: exp(-0.5 * (X - mean) * conic * (X - mean)) * splat opacity
-                float a = cov2Dv.x;
-                float d = cov2Dv.z;
-                float b = cov2Dv.y;
-                float D = a * d - b * b;
-                float trace = a + d;
-                float traceOver2 = 0.5 * trace;
-                float term2 = sqrt(max(0.1f, traceOver2 * traceOver2 - D));
-                float eigenValue1 = traceOver2 + term2;
-                float eigenValue2 = traceOver2 - term2;
-
-                if (pointCloudModeEnabled == 1) {
-                    eigenValue1 = eigenValue2 = 0.2;
-                }
-
-                if (eigenValue2 <= 0.0) return;
-
-                vec2 eigenVector1 = normalize(vec2(b, eigenValue1 - a));
-                // since the eigen vectors are orthogonal, we derive the second one from the first
-                vec2 eigenVector2 = vec2(eigenVector1.y, -eigenVector1.x);
-
-                // We use sqrt(8) standard deviations instead of 3 to eliminate more of the splat with a very low opacity.
-                vec2 basisVector1 = eigenVector1 * splatScale * min(sqrt8 * sqrt(eigenValue1), ${parseInt(maxScreenSpaceSplatSize)}.0);
-                vec2 basisVector2 = eigenVector2 * splatScale * min(sqrt8 * sqrt(eigenValue2), ${parseInt(maxScreenSpaceSplatSize)}.0);
-                `;
-
-            if (enableOptionalEffects) {
-                vertexShaderSource += `
-                    vColor.a *= splatOpacityFromScene;
-                `;
-            }
-
-            vertexShaderSource += `
-                vec2 ndcOffset = vec2(vPosition.x * basisVector1 + vPosition.y * basisVector2) *
-                                 basisViewport * 2.0 * inverseFocalAdjustment;
-
-                vec4 quadPos = vec4(ndcCenter.xy + ndcOffset, ndcCenter.z, 1.0);
-                gl_Position = quadPos;
-
-                // Scale the position data we send to the fragment shader
-                vPosition *= sqrt8;
-            `;
-
-        } else {
-            /*
-
-                glm::mat3 R = quat_to_rotmat(rot);
-                glm::mat3 S = scale_to_mat(scale, mod);
-                glm::mat3 L = R * S;
-
-                // center of Gaussians in the camera coordinate
-                glm::mat3x4 splat2world = glm::mat3x4(
-                    glm::vec4(L[0], 0.0),
-                    glm::vec4(L[1], 0.0),
-                    glm::vec4(p_orig.x, p_orig.y, p_orig.z, 1)
-                );
-
-                glm::mat4 world2ndc = glm::mat4(
-                    projmatrix[0], projmatrix[4], projmatrix[8], projmatrix[12],
-                    projmatrix[1], projmatrix[5], projmatrix[9], projmatrix[13],
-                    projmatrix[2], projmatrix[6], projmatrix[10], projmatrix[14],
-                    projmatrix[3], projmatrix[7], projmatrix[11], projmatrix[15]
-                );
-
-                glm::mat3x4 ndc2pix = glm::mat3x4(
-                    glm::vec4(float(W) / 2.0, 0.0, 0.0, float(W-1) / 2.0),
-                    glm::vec4(0.0, float(H) / 2.0, 0.0, float(H-1) / 2.0),
-                    glm::vec4(0.0, 0.0, 0.0, 1.0)
-                );
-
-                T = glm::transpose(splat2world) * world2ndc * ndc2pix;
-                normal = transformVec4x3({L[2].x, L[2].y, L[2].z}, viewmatrix);
-
-            */
-
-            // Compute a 2D-to-2D mapping matrix from a tangent plane into a image plane
-            // given a 2D gaussian parameters. T = WH (from the paper: https://arxiv.org/pdf/2403.17888)
-            vertexShaderSource += `
-
-                vec4 scaleRotationA = texture(scaleRotationsTexture, getDataUVF(nearestEvenIndex, 1.5,
-                                                                                oddOffset, scaleRotationsTextureSize));
-                vec4 scaleRotationB = texture(scaleRotationsTexture, getDataUVF(nearestEvenIndex, 1.5,
-                                                                                oddOffset + uint(1), scaleRotationsTextureSize));
-
-                vec3 scaleRotation123 = vec3(scaleRotationA.rgb) * (1.0 - fOddOffset) +
-                                        vec3(scaleRotationA.ba, scaleRotationB.r) * fOddOffset;
-                vec3 scaleRotation456 = vec3(scaleRotationA.a, scaleRotationB.rg) * (1.0 - fOddOffset) +
-                                        vec3(scaleRotationB.gba) * fOddOffset;
-
-                float missingW = sqrt(1.0 - scaleRotation456.x * scaleRotation456.x - scaleRotation456.y *
-                                      scaleRotation456.y - scaleRotation456.z * scaleRotation456.z);
-                mat3 R = quaternionToRotationMatrix(scaleRotation456.r, scaleRotation456.g, scaleRotation456.b, missingW);
-                mat3 S = mat3(scaleRotation123.r, 0.0, 0.0,
-                              0.0, scaleRotation123.g, 0.0,
-                              0.0, 0.0, scaleRotation123.b);
-                
-                mat3 L = R * S;
-
-                mat3x4 splat2World = mat3x4(vec4(L[0], 0.0),
-                                            vec4(L[1], 0.0),
-                                            vec4(splatCenter.x, splatCenter.y, splatCenter.z, 1.0));
-
-                mat4 world2ndc = transpose(projectionMatrix * transformModelViewMatrix);
-
-                mat3x4 ndc2pix = mat3x4(vec4(viewport.x / 2.0, 0.0, 0.0, (viewport.x - 1.0) / 2.0),
-                                        vec4(0.0, viewport.y / 2.0, 0.0, (viewport.y - 1.0) / 2.0),
-                                        vec4(0.0, 0.0, 0.0, 1.0));
-
-                mat3 T = transpose(splat2World) * world2ndc * ndc2pix;
-                vec3 normal = vec3(viewMatrix * vec4(L[0][2], L[1][2], L[2][2], 0.0));
-            `;
-
-            /*
-                float3 T0 = {T[0][0], T[0][1], T[0][2]};
-                float3 T1 = {T[1][0], T[1][1], T[1][2]};
-                float3 T3 = {T[2][0], T[2][1], T[2][2]};
-
-                // Compute AABB
-                float3 temp_point = {1.0f, 1.0f, -1.0f};
-                float distance = sumf3(T3 * T3 * temp_point);
-                float3 f = (1 / distance) * temp_point;
-                if (distance == 0.0) return false;
-
-                point_image = {
-                    sumf3(f * T0 * T3),
-                    sumf3(f * T1 * T3)
-                };
-
-                float2 temp = {
-                    sumf3(f * T0 * T0),
-                    sumf3(f * T1 * T1)
-                };
-                float2 half_extend = point_image * point_image - temp;
-                extent = sqrtf2(maxf2(1e-4, half_extend));
-                return true;
-            */
-            // Computing the bounding box of the 2D Gaussian and its center
-            // The center of the bounding box is used to create a low pass filter.
-            // This code is based off the reference implementation and creates an AABB aligned
-            // with the screen for the quad to be rendered.
-            const referenceQuadGeneration = `
-                vec3 T0 = vec3(T[0][0], T[0][1], T[0][2]);
-                vec3 T1 = vec3(T[1][0], T[1][1], T[1][2]);
-                vec3 T3 = vec3(T[2][0], T[2][1], T[2][2]);
-
-                vec3 tempPoint = vec3(1.0, 1.0, -1.0);
-                float distance = (T3.x * T3.x * tempPoint.x) + (T3.y * T3.y * tempPoint.y) + (T3.z * T3.z * tempPoint.z);
-                vec3 f = (1.0 / distance) * tempPoint;
-                if (abs(distance) < 0.00001) return;
-
-                float pointImageX = (T0.x * T3.x * f.x) + (T0.y * T3.y * f.y) + (T0.z * T3.z * f.z);
-                float pointImageY = (T1.x * T3.x * f.x) + (T1.y * T3.y * f.y) + (T1.z * T3.z * f.z);
-                vec2 pointImage = vec2(pointImageX, pointImageY);
-
-                float tempX = (T0.x * T0.x * f.x) + (T0.y * T0.y * f.y) + (T0.z * T0.z * f.z);
-                float tempY = (T1.x * T1.x * f.x) + (T1.y * T1.y * f.y) + (T1.z * T1.z * f.z);
-                vec2 temp = vec2(tempX, tempY);
-
-                vec2 halfExtend = pointImage * pointImage - temp;
-                vec2 extent = sqrt(max(vec2(0.0001), halfExtend));
-                float radius = max(extent.x, extent.y);
-
-                vec2 ndcOffset = ((position.xy * radius * 3.0) * basisViewport * 2.0);
-
-                vec4 quadPos = vec4(ndcCenter.xy + ndcOffset, ndcCenter.z, 1.0);
-                gl_Position = quadPos;
-
-                vT = T;
-                vQuadCenter = pointImage;
-                vFragCoord = (quadPos.xy * 0.5 + 0.5) * viewport;
-            `;
-
-            const useRefImplementation = false;
-            if (useRefImplementation) {
-                vertexShaderSource += referenceQuadGeneration;
-            } else {
-                // Create a quad that is aligned with the eigen vectors of the projected gaussian for rendering.
-                // This is a different approach than the reference implementation, similar to how the rendering of
-                // 3D gaussians in this viewer differs from the reference implementation. If the quad is too small
-                // (smaller than a pixel), then revert to the reference implementation.
-                vertexShaderSource += `
-
-                    mat4 splat2World4 = mat4(vec4(L[0], 0.0),
-                                            vec4(L[1], 0.0),
-                                            vec4(L[2], 0.0),
-                                            vec4(splatCenter.x, splatCenter.y, splatCenter.z, 1.0));
-
-                    mat4 Tt = transpose(transpose(splat2World4) * world2ndc);
-
-                    vec4 tempPoint1 = Tt * vec4(1.0, 0.0, 0.0, 1.0);
-                    tempPoint1 /= tempPoint1.w;
-
-                    vec4 tempPoint2 = Tt * vec4(0.0, 1.0, 0.0, 1.0);
-                    tempPoint2 /= tempPoint2.w;
-
-                    vec4 center = Tt * vec4(0.0, 0.0, 0.0, 1.0);
-                    center /= center.w;
-
-                    vec2 basisVector1 = tempPoint1.xy - center.xy;
-                    vec2 basisVector2 = tempPoint2.xy - center.xy;
-
-                    vec2 basisVector1Screen = basisVector1 * 0.5 * viewport;
-                    vec2 basisVector2Screen = basisVector2 * 0.5 * viewport;
-
-                    const float minPix = 1.;
-                    if (length(basisVector1Screen) < minPix || length(basisVector2Screen) < minPix) {
-                        ${referenceQuadGeneration}
-                    } else {
-                        vec2 ndcOffset = vec2(position.x * basisVector1 + position.y * basisVector2) * 3.0 * inverseFocalAdjustment;
-                        vec4 quadPos = vec4(ndcCenter.xy + ndcOffset, ndcCenter.z, 1.0);
-                        gl_Position = quadPos;
-
-                        vT = T;
-                        vQuadCenter = center.xy;
-                        vFragCoord = (quadPos.xy * 0.5 + 0.5) * viewport;
-                    }
-                `;
-            }
-        }
-
-        vertexShaderSource += `
-            
-            if (fadeInComplete == 0) {
-                float opacityAdjust = 1.0;
-                float centerDist = length(splatCenter - sceneCenter);
-                float renderTime = max(currentTime - firstRenderTime, 0.0);
-
-                float fadeDistance = 0.75;
-                float distanceLoadFadeInFactor = step(visibleRegionFadeStartRadius, centerDist);
-                distanceLoadFadeInFactor = (1.0 - distanceLoadFadeInFactor) +
-                                        (1.0 - clamp((centerDist - visibleRegionFadeStartRadius) / fadeDistance, 0.0, 1.0)) *
-                                        distanceLoadFadeInFactor;
-                opacityAdjust *= distanceLoadFadeInFactor;
-                vColor.a *= opacityAdjust;
-            }
-        }
-        `;
-
-        return vertexShaderSource;
-    }
 }

--- a/src/splatmesh/SplatMaterial2D.js
+++ b/src/splatmesh/SplatMaterial2D.js
@@ -1,0 +1,344 @@
+import * as THREE from 'three';
+import { SplatMaterial } from './SplatMaterial.js';
+
+export class SplatMaterial2D {
+
+    /**
+     * Build the Three.js material that is used to render the splats.
+     * @param {number} dynamicMode If true, it means the scene geometry represented by this splat mesh is not stationary or
+     *                             that the splat count might change
+     * @param {boolean} enableOptionalEffects When true, allows for usage of extra properties and attributes in the shader for effects
+     *                                        such as opacity adjustment. Default is false for performance reasons.
+     * @param {number} splatScale Value by which all splats are scaled in screen-space (default is 1.0)
+     * @param {number} pointCloudModeEnabled Render all splats as screen-space circles
+     * @param {number} maxSphericalHarmonicsDegree Degree of spherical harmonics to utilize in rendering splats
+     * @return {THREE.ShaderMaterial}
+     */
+    static build(dynamicMode = false, enableOptionalEffects = false, splatScale = 1.0,
+                 pointCloudModeEnabled = false, maxSphericalHarmonicsDegree = 0) {
+
+        const customVertexVars = `
+            uniform vec2 scaleRotationsTextureSize;
+            uniform highp sampler2D scaleRotationsTexture;
+            varying mat3 vT;
+            varying vec2 vQuadCenter;
+            varying vec2 vFragCoord;
+        `;
+
+        let vertexShaderSource = SplatMaterial.buildVertexShaderBase(dynamicMode, enableOptionalEffects,
+                                                                     maxSphericalHarmonicsDegree, customVertexVars);
+        vertexShaderSource += SplatMaterial2D.buildVertexShaderProjection();
+        const fragmentShaderSource = SplatMaterial2D.buildFragmentShader();
+
+        const uniforms = SplatMaterial.getUniforms(dynamicMode, enableOptionalEffects,
+                                                   maxSphericalHarmonicsDegree, splatScale, pointCloudModeEnabled);
+
+        uniforms['scaleRotationsTexture'] = {
+            'type': 't',
+            'value': null
+        };
+        uniforms['scaleRotationsTextureSize'] = {
+            'type': 'v2',
+            'value': new THREE.Vector2(1024, 1024)
+        };
+
+        const material = new THREE.ShaderMaterial({
+            uniforms: uniforms,
+            vertexShader: vertexShaderSource,
+            fragmentShader: fragmentShaderSource,
+            transparent: true,
+            alphaTest: 1.0,
+            blending: THREE.NormalBlending,
+            depthTest: true,
+            depthWrite: false,
+            side: THREE.DoubleSide
+        });
+
+        return material;
+    }
+
+    static buildVertexShaderProjection() {
+        /*
+            glm::mat3 R = quat_to_rotmat(rot);
+            glm::mat3 S = scale_to_mat(scale, mod);
+            glm::mat3 L = R * S;
+
+            // center of Gaussians in the camera coordinate
+            glm::mat3x4 splat2world = glm::mat3x4(
+                glm::vec4(L[0], 0.0),
+                glm::vec4(L[1], 0.0),
+                glm::vec4(p_orig.x, p_orig.y, p_orig.z, 1)
+            );
+
+            glm::mat4 world2ndc = glm::mat4(
+                projmatrix[0], projmatrix[4], projmatrix[8], projmatrix[12],
+                projmatrix[1], projmatrix[5], projmatrix[9], projmatrix[13],
+                projmatrix[2], projmatrix[6], projmatrix[10], projmatrix[14],
+                projmatrix[3], projmatrix[7], projmatrix[11], projmatrix[15]
+            );
+
+            glm::mat3x4 ndc2pix = glm::mat3x4(
+                glm::vec4(float(W) / 2.0, 0.0, 0.0, float(W-1) / 2.0),
+                glm::vec4(0.0, float(H) / 2.0, 0.0, float(H-1) / 2.0),
+                glm::vec4(0.0, 0.0, 0.0, 1.0)
+            );
+
+            T = glm::transpose(splat2world) * world2ndc * ndc2pix;
+            normal = transformVec4x3({L[2].x, L[2].y, L[2].z}, viewmatrix);
+
+        */
+
+        // Compute a 2D-to-2D mapping matrix from a tangent plane into a image plane
+        // given a 2D gaussian parameters. T = WH (from the paper: https://arxiv.org/pdf/2403.17888)
+        let vertexShaderSource = `
+
+            vec4 scaleRotationA = texture(scaleRotationsTexture, getDataUVF(nearestEvenIndex, 1.5,
+                                                                            oddOffset, scaleRotationsTextureSize));
+            vec4 scaleRotationB = texture(scaleRotationsTexture, getDataUVF(nearestEvenIndex, 1.5,
+                                                                            oddOffset + uint(1), scaleRotationsTextureSize));
+
+            vec3 scaleRotation123 = vec3(scaleRotationA.rgb) * (1.0 - fOddOffset) +
+                                    vec3(scaleRotationA.ba, scaleRotationB.r) * fOddOffset;
+            vec3 scaleRotation456 = vec3(scaleRotationA.a, scaleRotationB.rg) * (1.0 - fOddOffset) +
+                                    vec3(scaleRotationB.gba) * fOddOffset;
+
+            float missingW = sqrt(1.0 - scaleRotation456.x * scaleRotation456.x - scaleRotation456.y *
+                                    scaleRotation456.y - scaleRotation456.z * scaleRotation456.z);
+            mat3 R = quaternionToRotationMatrix(scaleRotation456.r, scaleRotation456.g, scaleRotation456.b, missingW);
+            mat3 S = mat3(scaleRotation123.r, 0.0, 0.0,
+                            0.0, scaleRotation123.g, 0.0,
+                            0.0, 0.0, scaleRotation123.b);
+            
+            mat3 L = R * S;
+
+            mat3x4 splat2World = mat3x4(vec4(L[0], 0.0),
+                                        vec4(L[1], 0.0),
+                                        vec4(splatCenter.x, splatCenter.y, splatCenter.z, 1.0));
+
+            mat4 world2ndc = transpose(projectionMatrix * transformModelViewMatrix);
+
+            mat3x4 ndc2pix = mat3x4(vec4(viewport.x / 2.0, 0.0, 0.0, (viewport.x - 1.0) / 2.0),
+                                    vec4(0.0, viewport.y / 2.0, 0.0, (viewport.y - 1.0) / 2.0),
+                                    vec4(0.0, 0.0, 0.0, 1.0));
+
+            mat3 T = transpose(splat2World) * world2ndc * ndc2pix;
+            vec3 normal = vec3(viewMatrix * vec4(L[0][2], L[1][2], L[2][2], 0.0));
+        `;
+
+        /*
+            float3 T0 = {T[0][0], T[0][1], T[0][2]};
+            float3 T1 = {T[1][0], T[1][1], T[1][2]};
+            float3 T3 = {T[2][0], T[2][1], T[2][2]};
+
+            // Compute AABB
+            float3 temp_point = {1.0f, 1.0f, -1.0f};
+            float distance = sumf3(T3 * T3 * temp_point);
+            float3 f = (1 / distance) * temp_point;
+            if (distance == 0.0) return false;
+
+            point_image = {
+                sumf3(f * T0 * T3),
+                sumf3(f * T1 * T3)
+            };
+
+            float2 temp = {
+                sumf3(f * T0 * T0),
+                sumf3(f * T1 * T1)
+            };
+            float2 half_extend = point_image * point_image - temp;
+            extent = sqrtf2(maxf2(1e-4, half_extend));
+            return true;
+        */
+        // Computing the bounding box of the 2D Gaussian and its center
+        // The center of the bounding box is used to create a low pass filter.
+        // This code is based off the reference implementation and creates an AABB aligned
+        // with the screen for the quad to be rendered.
+        const referenceQuadGeneration = `
+            vec3 T0 = vec3(T[0][0], T[0][1], T[0][2]);
+            vec3 T1 = vec3(T[1][0], T[1][1], T[1][2]);
+            vec3 T3 = vec3(T[2][0], T[2][1], T[2][2]);
+
+            vec3 tempPoint = vec3(1.0, 1.0, -1.0);
+            float distance = (T3.x * T3.x * tempPoint.x) + (T3.y * T3.y * tempPoint.y) + (T3.z * T3.z * tempPoint.z);
+            vec3 f = (1.0 / distance) * tempPoint;
+            if (abs(distance) < 0.00001) return;
+
+            float pointImageX = (T0.x * T3.x * f.x) + (T0.y * T3.y * f.y) + (T0.z * T3.z * f.z);
+            float pointImageY = (T1.x * T3.x * f.x) + (T1.y * T3.y * f.y) + (T1.z * T3.z * f.z);
+            vec2 pointImage = vec2(pointImageX, pointImageY);
+
+            float tempX = (T0.x * T0.x * f.x) + (T0.y * T0.y * f.y) + (T0.z * T0.z * f.z);
+            float tempY = (T1.x * T1.x * f.x) + (T1.y * T1.y * f.y) + (T1.z * T1.z * f.z);
+            vec2 temp = vec2(tempX, tempY);
+
+            vec2 halfExtend = pointImage * pointImage - temp;
+            vec2 extent = sqrt(max(vec2(0.0001), halfExtend));
+            float radius = max(extent.x, extent.y);
+
+            vec2 ndcOffset = ((position.xy * radius * 3.0) * basisViewport * 2.0);
+
+            vec4 quadPos = vec4(ndcCenter.xy + ndcOffset, ndcCenter.z, 1.0);
+            gl_Position = quadPos;
+
+            vT = T;
+            vQuadCenter = pointImage;
+            vFragCoord = (quadPos.xy * 0.5 + 0.5) * viewport;
+        `;
+
+        const useRefImplementation = false;
+        if (useRefImplementation) {
+            vertexShaderSource += referenceQuadGeneration;
+        } else {
+            // Create a quad that is aligned with the eigen vectors of the projected gaussian for rendering.
+            // This is a different approach than the reference implementation, similar to how the rendering of
+            // 3D gaussians in this viewer differs from the reference implementation. If the quad is too small
+            // (smaller than a pixel), then revert to the reference implementation.
+            vertexShaderSource += `
+
+                mat4 splat2World4 = mat4(vec4(L[0], 0.0),
+                                        vec4(L[1], 0.0),
+                                        vec4(L[2], 0.0),
+                                        vec4(splatCenter.x, splatCenter.y, splatCenter.z, 1.0));
+
+                mat4 Tt = transpose(transpose(splat2World4) * world2ndc);
+
+                vec4 tempPoint1 = Tt * vec4(1.0, 0.0, 0.0, 1.0);
+                tempPoint1 /= tempPoint1.w;
+
+                vec4 tempPoint2 = Tt * vec4(0.0, 1.0, 0.0, 1.0);
+                tempPoint2 /= tempPoint2.w;
+
+                vec4 center = Tt * vec4(0.0, 0.0, 0.0, 1.0);
+                center /= center.w;
+
+                vec2 basisVector1 = tempPoint1.xy - center.xy;
+                vec2 basisVector2 = tempPoint2.xy - center.xy;
+
+                vec2 basisVector1Screen = basisVector1 * 0.5 * viewport;
+                vec2 basisVector2Screen = basisVector2 * 0.5 * viewport;
+
+                const float minPix = 1.;
+                if (length(basisVector1Screen) < minPix || length(basisVector2Screen) < minPix) {
+                    ${referenceQuadGeneration}
+                } else {
+                    vec2 ndcOffset = vec2(position.x * basisVector1 + position.y * basisVector2) * 3.0 * inverseFocalAdjustment;
+                    vec4 quadPos = vec4(ndcCenter.xy + ndcOffset, ndcCenter.z, 1.0);
+                    gl_Position = quadPos;
+
+                    vT = T;
+                    vQuadCenter = center.xy;
+                    vFragCoord = (quadPos.xy * 0.5 + 0.5) * viewport;
+                }
+            `;
+        }
+
+        vertexShaderSource += SplatMaterial.getVertexShaderFadeIn();
+        vertexShaderSource += `}`;
+
+        return vertexShaderSource;
+    }
+
+    static buildFragmentShader() {
+
+        let fragmentShaderSource = `
+            precision highp float;
+            #include <common>
+
+            uniform vec3 debugColor;
+
+            varying vec4 vColor;
+            varying vec2 vUv;
+            varying vec2 vPosition;
+            varying mat3 vT;
+            varying vec2 vQuadCenter;
+            varying vec2 vFragCoord;
+
+            /*
+                const float2 xy = collected_xy[j];
+                const float3 Tu = collected_Tu[j];
+                const float3 Tv = collected_Tv[j];
+                const float3 Tw = collected_Tw[j];
+                float3 k = pix.x * Tw - Tu;
+                float3 l = pix.y * Tw - Tv;
+                float3 p = cross(k, l);
+                if (p.z == 0.0) continue;
+                float2 s = {p.x / p.z, p.y / p.z};
+                float rho3d = (s.x * s.x + s.y * s.y);
+                float2 d = {xy.x - pixf.x, xy.y - pixf.y};
+                float rho2d = FilterInvSquare * (d.x * d.x + d.y * d.y);
+
+                // compute intersection and depth
+                float rho = min(rho3d, rho2d);
+                float depth = (rho3d <= rho2d) ? (s.x * Tw.x + s.y * Tw.y) + Tw.z : Tw.z;
+                if (depth < near_n) continue;
+                float4 nor_o = collected_normal_opacity[j];
+                float normal[3] = {nor_o.x, nor_o.y, nor_o.z};
+                float opa = nor_o.w;
+
+                float power = -0.5f * rho;
+                if (power > 0.0f)
+                    continue;
+
+                // Eq. (2) from 3D Gaussian splatting paper.
+                // Obtain alpha by multiplying with Gaussian opacity
+                // and its exponential falloff from mean.
+                // Avoid numerical instabilities (see paper appendix).
+                float alpha = min(0.99f, opa * exp(power));
+                if (alpha < 1.0f / 255.0f)
+                    continue;
+                float test_T = T * (1 - alpha);
+                if (test_T < 0.0001f)
+                {
+                    done = true;
+                    continue;
+                }
+
+                float w = alpha * T;
+            */
+            void main () {
+
+                const float FilterInvSquare = 2.0;
+                const float near_n = 0.2;
+                const float T = 1.0;
+
+                vec2 xy = vQuadCenter;
+                vec3 Tu = vT[0];
+                vec3 Tv = vT[1];
+                vec3 Tw = vT[2];
+                vec3 k = vFragCoord.x * Tw - Tu;
+                vec3 l = vFragCoord.y * Tw - Tv;
+                vec3 p = cross(k, l);
+                if (p.z == 0.0) discard;
+                vec2 s = vec2(p.x / p.z, p.y / p.z);
+                float rho3d = (s.x * s.x + s.y * s.y); 
+                vec2 d = vec2(xy.x - vFragCoord.x, xy.y - vFragCoord.y);
+                float rho2d = FilterInvSquare * (d.x * d.x + d.y * d.y); 
+
+                // compute intersection and depth
+                float rho = min(rho3d, rho2d);
+                float depth = (rho3d <= rho2d) ? (s.x * Tw.x + s.y * Tw.y) + Tw.z : Tw.z; 
+                if (depth < near_n) discard;
+                //  vec4 nor_o = collected_normal_opacity[j];
+                //  float normal[3] = {nor_o.x, nor_o.y, nor_o.z};
+                float opa = vColor.a;
+
+                float power = -0.5f * rho;
+                if (power > 0.0f) discard;
+
+                // Eq. (2) from 3D Gaussian splatting paper.
+                // Obtain alpha by multiplying with Gaussian opacity
+                // and its exponential falloff from mean.
+                // Avoid numerical instabilities (see paper appendix). 
+                float alpha = min(0.99f, opa * exp(power));
+                if (alpha < 1.0f / 255.0f) discard;
+                float test_T = T * (1.0 - alpha);
+                if (test_T < 0.0001)discard;
+
+                float w = alpha * T;
+                gl_FragColor = vec4(vColor.rgb, w);
+            }
+        `;
+
+        return fragmentShaderSource;
+    }
+}

--- a/src/splatmesh/SplatMaterial3D.js
+++ b/src/splatmesh/SplatMaterial3D.js
@@ -1,0 +1,226 @@
+import * as THREE from 'three';
+import { SplatMaterial } from './SplatMaterial.js';
+
+export class SplatMaterial3D {
+
+    /**
+     * Build the Three.js material that is used to render the splats.
+     * @param {number} dynamicMode If true, it means the scene geometry represented by this splat mesh is not stationary or
+     *                             that the splat count might change
+     * @param {boolean} enableOptionalEffects When true, allows for usage of extra properties and attributes in the shader for effects
+     *                                        such as opacity adjustment. Default is false for performance reasons.
+     * @param {boolean} antialiased If true, calculate compensation factor to deal with gaussians being rendered at a significantly
+     *                              different resolution than that of their training
+     * @param {number} maxScreenSpaceSplatSize The maximum clip space splat size
+     * @param {number} splatScale Value by which all splats are scaled in screen-space (default is 1.0)
+     * @param {number} pointCloudModeEnabled Render all splats as screen-space circles
+     * @param {number} maxSphericalHarmonicsDegree Degree of spherical harmonics to utilize in rendering splats
+     * @return {THREE.ShaderMaterial}
+     */
+    static build(dynamicMode = false, enableOptionalEffects = false, antialiased = false,
+                 maxScreenSpaceSplatSize = 2048, splatScale = 1.0, pointCloudModeEnabled = false, maxSphericalHarmonicsDegree = 0) {
+
+        const customVertexVars = `
+            uniform vec2 covariancesTextureSize;
+            uniform highp sampler2D covariancesTexture;
+        `;
+
+        let vertexShaderSource = SplatMaterial.buildVertexShaderBase(dynamicMode, enableOptionalEffects,
+                                                                     maxSphericalHarmonicsDegree, customVertexVars);
+        vertexShaderSource += SplatMaterial3D.buildVertexShaderProjection(antialiased, enableOptionalEffects, maxScreenSpaceSplatSize);
+        const fragmentShaderSource = SplatMaterial3D.buildFragmentShader();
+
+        const uniforms = SplatMaterial.getUniforms(dynamicMode, enableOptionalEffects,
+                                                   maxSphericalHarmonicsDegree, splatScale, pointCloudModeEnabled);
+
+        uniforms['covariancesTexture'] = {
+            'type': 't',
+            'value': null
+        };
+        uniforms['covariancesTextureSize'] = {
+            'type': 'v2',
+            'value': new THREE.Vector2(1024, 1024)
+        };
+
+        const material = new THREE.ShaderMaterial({
+            uniforms: uniforms,
+            vertexShader: vertexShaderSource,
+            fragmentShader: fragmentShaderSource,
+            transparent: true,
+            alphaTest: 1.0,
+            blending: THREE.NormalBlending,
+            depthTest: true,
+            depthWrite: false,
+            side: THREE.DoubleSide
+        });
+
+        return material;
+    }
+
+    static buildVertexShaderProjection(antialiased, enableOptionalEffects, maxScreenSpaceSplatSize) {
+        let vertexShaderSource = `
+
+            vec4 sampledCovarianceA = texture(covariancesTexture, getDataUVF(nearestEvenIndex, 1.5, oddOffset,
+                                                                            covariancesTextureSize));
+            vec4 sampledCovarianceB = texture(covariancesTexture, getDataUVF(nearestEvenIndex, 1.5, oddOffset + uint(1),
+                                                                            covariancesTextureSize));
+
+            vec3 cov3D_M11_M12_M13 = vec3(sampledCovarianceA.rgb) * (1.0 - fOddOffset) +
+                                    vec3(sampledCovarianceA.ba, sampledCovarianceB.r) * fOddOffset;
+            vec3 cov3D_M22_M23_M33 = vec3(sampledCovarianceA.a, sampledCovarianceB.rg) * (1.0 - fOddOffset) +
+                                    vec3(sampledCovarianceB.gba) * fOddOffset;
+
+            // Construct the 3D covariance matrix
+            mat3 Vrk = mat3(
+                cov3D_M11_M12_M13.x, cov3D_M11_M12_M13.y, cov3D_M11_M12_M13.z,
+                cov3D_M11_M12_M13.y, cov3D_M22_M23_M33.x, cov3D_M22_M23_M33.y,
+                cov3D_M11_M12_M13.z, cov3D_M22_M23_M33.y, cov3D_M22_M23_M33.z
+            );
+
+            mat3 J;
+            if (orthographicMode == 1) {
+                // Since the projection is linear, we don't need an approximation
+                J = transpose(mat3(orthoZoom, 0.0, 0.0,
+                                0.0, orthoZoom, 0.0,
+                                0.0, 0.0, 0.0));
+            } else {
+                // Construct the Jacobian of the affine approximation of the projection matrix. It will be used to transform the
+                // 3D covariance matrix instead of using the actual projection matrix because that transformation would
+                // require a non-linear component (perspective division) which would yield a non-gaussian result.
+                float s = 1.0 / (viewCenter.z * viewCenter.z);
+                J = mat3(
+                    focal.x / viewCenter.z, 0., -(focal.x * viewCenter.x) * s,
+                    0., focal.y / viewCenter.z, -(focal.y * viewCenter.y) * s,
+                    0., 0., 0.
+                );
+            }
+
+            // Concatenate the projection approximation with the model-view transformation
+            mat3 W = transpose(mat3(transformModelViewMatrix));
+            mat3 T = W * J;
+
+            // Transform the 3D covariance matrix (Vrk) to compute the 2D covariance matrix
+            mat3 cov2Dm = transpose(T) * Vrk * T;
+            `;
+
+        if (antialiased) {
+            vertexShaderSource += `
+                float detOrig = cov2Dm[0][0] * cov2Dm[1][1] - cov2Dm[0][1] * cov2Dm[0][1];
+                cov2Dm[0][0] += 0.3;
+                cov2Dm[1][1] += 0.3;
+                float detBlur = cov2Dm[0][0] * cov2Dm[1][1] - cov2Dm[0][1] * cov2Dm[0][1];
+                vColor.a *= sqrt(max(detOrig / detBlur, 0.0));
+                if (vColor.a < minAlpha) return;
+            `;
+        } else {
+            vertexShaderSource += `
+                cov2Dm[0][0] += 0.3;
+                cov2Dm[1][1] += 0.3;
+            `;
+        }
+
+        vertexShaderSource += `
+
+            // We are interested in the upper-left 2x2 portion of the projected 3D covariance matrix because
+            // we only care about the X and Y values. We want the X-diagonal, cov2Dm[0][0],
+            // the Y-diagonal, cov2Dm[1][1], and the correlation between the two cov2Dm[0][1]. We don't
+            // need cov2Dm[1][0] because it is a symetric matrix.
+            vec3 cov2Dv = vec3(cov2Dm[0][0], cov2Dm[0][1], cov2Dm[1][1]);
+
+            // We now need to solve for the eigen-values and eigen vectors of the 2D covariance matrix
+            // so that we can determine the 2D basis for the splat. This is done using the method described
+            // here: https://people.math.harvard.edu/~knill/teaching/math21b2004/exhibits/2dmatrices/index.html
+            // After calculating the eigen-values and eigen-vectors, we calculate the basis for rendering the splat
+            // by normalizing the eigen-vectors and then multiplying them by (sqrt(8) * sqrt(eigen-value)), which is
+            // equal to scaling them by sqrt(8) standard deviations.
+            //
+            // This is a different approach than in the original work at INRIA. In that work they compute the
+            // max extents of the projected splat in screen space to form a screen-space aligned bounding rectangle
+            // which forms the geometry that is actually rasterized. The dimensions of that bounding box are 3.0
+            // times the square root of the maximum eigen-value, or 3 standard deviations. They then use the inverse
+            // 2D covariance matrix (called 'conic') in the CUDA rendering thread to determine fragment opacity by
+            // calculating the full gaussian: exp(-0.5 * (X - mean) * conic * (X - mean)) * splat opacity
+            float a = cov2Dv.x;
+            float d = cov2Dv.z;
+            float b = cov2Dv.y;
+            float D = a * d - b * b;
+            float trace = a + d;
+            float traceOver2 = 0.5 * trace;
+            float term2 = sqrt(max(0.1f, traceOver2 * traceOver2 - D));
+            float eigenValue1 = traceOver2 + term2;
+            float eigenValue2 = traceOver2 - term2;
+
+            if (pointCloudModeEnabled == 1) {
+                eigenValue1 = eigenValue2 = 0.2;
+            }
+
+            if (eigenValue2 <= 0.0) return;
+
+            vec2 eigenVector1 = normalize(vec2(b, eigenValue1 - a));
+            // since the eigen vectors are orthogonal, we derive the second one from the first
+            vec2 eigenVector2 = vec2(eigenVector1.y, -eigenVector1.x);
+
+            // We use sqrt(8) standard deviations instead of 3 to eliminate more of the splat with a very low opacity.
+            vec2 basisVector1 = eigenVector1 * splatScale * min(sqrt8 * sqrt(eigenValue1), ${parseInt(maxScreenSpaceSplatSize)}.0);
+            vec2 basisVector2 = eigenVector2 * splatScale * min(sqrt8 * sqrt(eigenValue2), ${parseInt(maxScreenSpaceSplatSize)}.0);
+            `;
+
+        if (enableOptionalEffects) {
+            vertexShaderSource += `
+                vColor.a *= splatOpacityFromScene;
+            `;
+        }
+
+        vertexShaderSource += `
+            vec2 ndcOffset = vec2(vPosition.x * basisVector1 + vPosition.y * basisVector2) *
+                            basisViewport * 2.0 * inverseFocalAdjustment;
+
+            vec4 quadPos = vec4(ndcCenter.xy + ndcOffset, ndcCenter.z, 1.0);
+            gl_Position = quadPos;
+
+            // Scale the position data we send to the fragment shader
+            vPosition *= sqrt8;
+        `;
+
+        vertexShaderSource += SplatMaterial.getVertexShaderFadeIn();
+        vertexShaderSource += `}`;
+
+        return vertexShaderSource;
+    }
+
+    static buildFragmentShader() {
+        let fragmentShaderSource = `
+            precision highp float;
+            #include <common>
+ 
+            uniform vec3 debugColor;
+
+            varying vec4 vColor;
+            varying vec2 vUv;
+            varying vec2 vPosition;
+        `;
+
+        fragmentShaderSource += `
+            void main () {
+                // Compute the positional squared distance from the center of the splat to the current fragment.
+                float A = dot(vPosition, vPosition);
+                // Since the positional data in vPosition has been scaled by sqrt(8), the squared result will be
+                // scaled by a factor of 8. If the squared result is larger than 8, it means it is outside the ellipse
+                // defined by the rectangle formed by vPosition. It also means it's farther
+                // away than sqrt(8) standard deviations from the mean.
+                if (A > 8.0) discard;
+                vec3 color = vColor.rgb;
+
+                // Since the rendered splat is scaled by sqrt(8), the inverse covariance matrix that is part of
+                // the gaussian formula becomes the identity matrix. We're then left with (X - mean) * (X - mean),
+                // and since 'mean' is zero, we have X * X, which is the same as A:
+                float opacity = exp(-0.5 * A) * vColor.a;
+
+                gl_FragColor = vec4(color.rgb, opacity);
+            }
+        `;
+
+        return fragmentShaderSource;
+    }
+
+}

--- a/src/splatmesh/SplatMaterial3D.js
+++ b/src/splatmesh/SplatMaterial3D.js
@@ -24,7 +24,7 @@ export class SplatMaterial3D {
             uniform vec2 covariancesTextureSize;
             uniform highp sampler2D covariancesTexture;
             uniform highp usampler2D covariancesTextureHalfFloat;
-            uniform uint covariancesAreHalfFloat;
+            uniform int covariancesAreHalfFloat;
 
             void fromCovarianceHalfFloatV4(uvec4 val, out vec4 first, out vec4 second) {
                 vec2 r = unpackHalf2x16(val.r);
@@ -83,7 +83,7 @@ export class SplatMaterial3D {
             vec4 sampledCovarianceB;
             vec3 cov3D_M11_M12_M13;
             vec3 cov3D_M22_M23_M33;
-            if (covariancesAreHalfFloat == uint(0)) {
+            if (covariancesAreHalfFloat == 0) {
                 sampledCovarianceA = texture(covariancesTexture, getDataUVF(nearestEvenIndex, 1.5, oddOffset,
                                                                             covariancesTextureSize));
                 sampledCovarianceB = texture(covariancesTexture, getDataUVF(nearestEvenIndex, 1.5, oddOffset + uint(1),

--- a/src/splatmesh/SplatMesh.js
+++ b/src/splatmesh/SplatMesh.js
@@ -1763,6 +1763,12 @@ export class SplatMesh extends THREE.Mesh {
     fillSplatDataArrays(covariances, scales, rotations, centers, colors, sphericalHarmonics, applySceneTransform,
                         covarianceCompressionLevel = 0, scaleRotationCompressionLevel = 0, sphericalHarmonicsCompressionLevel = 1,
                         srcStart, srcEnd, destStart = 0) {
+        const scaleOverride = new THREE.Vector3(0, 0, 0);
+        if (this.splatRenderMode === SplatRenderMode.ThreeD) {
+            scaleOverride.set(undefined, undefined, undefined);
+        } else {
+            scaleOverride.set(undefined, undefined, 1);
+        }
 
         for (let i = 0; i < this.scenes.length; i++) {
             if (applySceneTransform === undefined || applySceneTransform === null) {
@@ -1780,7 +1786,7 @@ export class SplatMesh extends THREE.Mesh {
                     throw new Error('SplatMesh::fillSplatDataArrays() -> "scales" and "rotations" must both be valid.');
                 }
                 splatBuffer.fillSplatScaleRotationArray(scales, rotations, sceneTransform,
-                                                        srcStart, srcEnd, destStart, scaleRotationCompressionLevel);
+                                                        srcStart, srcEnd, destStart, scaleRotationCompressionLevel, scaleOverride);
             }
             if (centers) splatBuffer.fillSplatCenterArray(centers, sceneTransform, srcStart, srcEnd, destStart);
             if (colors) splatBuffer.fillSplatColorArray(colors, scene.minimumAlpha, srcStart, srcEnd, destStart);
@@ -1872,10 +1878,14 @@ export class SplatMesh extends THREE.Mesh {
     getSplatScaleAndRotation = function() {
 
         const paramsObj = {};
+        const scaleOverride = new THREE.Vector3();
 
         return function(globalIndex, outScale, outRotation, applySceneTransform) {
             this.getLocalSplatParameters(globalIndex, paramsObj, applySceneTransform);
-            paramsObj.splatBuffer.getSplatScaleAndRotation(paramsObj.localIndex, outScale, outRotation, paramsObj.sceneTransform);
+            scaleOverride.set(undefined, undefined, undefined);
+            if (this.splatRenderMode === SplatRenderMode.TwoD) scaleOverride.z = 0;
+            paramsObj.splatBuffer.getSplatScaleAndRotation(paramsObj.localIndex, outScale, outRotation,
+                                                           paramsObj.sceneTransform, scaleOverride);
         };
 
     }();

--- a/src/splatmesh/SplatMesh.js
+++ b/src/splatmesh/SplatMesh.js
@@ -960,7 +960,7 @@ export class SplatMesh extends THREE.Mesh {
             const paddedScaleRotations = scaleRotationsTextureDesc.data;
             const scaleRotationsTexture = scaleRotationsTextureDesc.texture;
             const elementsPerSplat = 6;
-            const bytesPerSplat = elementsPerSplat * (scaleRotationCompressionLevel === 0 ? 4 : 2);
+            const bytesPerElement = scaleRotationCompressionLevel === 0 ? 4 : 2;
 
             SplatMesh.updateScaleRotationsPaddedData(fromSplat, toSplat, this.splatDataTextures.baseData.scales,
                                                      this.splatDataTextures.baseData.rotations, paddedScaleRotations);
@@ -969,7 +969,7 @@ export class SplatMesh extends THREE.Mesh {
                 scaleRotationsTexture.needsUpdate = true;
             } else {
                 this.updateDataTexture(paddedScaleRotations, scaleRotationsTextureDesc.texture, scaleRotationsTextureDesc.size,
-                                       scaleRotationsTextureProps, SCALES_ROTATIONS_ELEMENTS_PER_TEXEL, elementsPerSplat, bytesPerSplat,
+                                       scaleRotationsTextureProps, SCALES_ROTATIONS_ELEMENTS_PER_TEXEL, elementsPerSplat, bytesPerElement,
                                        fromSplat, toSplat);
             }
         }
@@ -1097,12 +1097,12 @@ export class SplatMesh extends THREE.Mesh {
         };
     }
 
-    updateDataTexture(paddedData, texture, textureSize, textureProps, elementsPerTexel, elementsPerSplat, bytesPerSplat, from, to) {
+    updateDataTexture(paddedData, texture, textureSize, textureProps, elementsPerTexel, elementsPerSplat, bytesPerElement, from, to) {
         const gl = this.renderer.getContext();
         const updateRegion = SplatMesh.computeTextureUpdateRegion(from, to, textureSize.x, elementsPerTexel, elementsPerSplat);
         const updateElementCount = updateRegion.dataEnd - updateRegion.dataStart;
         const updateDataView = new paddedData.constructor(paddedData.buffer,
-                                                          updateRegion.dataStart * bytesPerSplat, updateElementCount);
+                                                          updateRegion.dataStart * bytesPerElement, updateElementCount);
         const updateHeight = updateRegion.endRow - updateRegion.startRow + 1;
         const glType = this.webGLUtils.convert(texture.type);
         const glFormat = this.webGLUtils.convert(texture.format, texture.colorSpace);

--- a/src/splatmesh/SplatMesh.js
+++ b/src/splatmesh/SplatMesh.js
@@ -387,6 +387,7 @@ export class SplatMesh extends THREE.Mesh {
                                 onSplatTreeIndexesUpload, onSplatTreeConstruction)
             .then(() => {
                 if (this.onSplatTreeReadyCallback) this.onSplatTreeReadyCallback(this.splatTree);
+                this.onSplatTreeReadyCallback = null;
             });
         }
 
@@ -538,7 +539,8 @@ export class SplatMesh extends THREE.Mesh {
         if (this.splatTree) {
             this.splatTree.dispose();
             this.splatTree = null;
-        } else if (this.baseSplatTree) {
+        }
+        if (this.baseSplatTree) {
             this.baseSplatTree.dispose();
             this.baseSplatTree = null;
         }

--- a/src/splatmesh/SplatMesh.js
+++ b/src/splatmesh/SplatMesh.js
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
-import { SplatMaterial } from './SplatMaterial.js';
+import { SplatMaterial3D } from './SplatMaterial3D.js';
+import { SplatMaterial2D } from './SplatMaterial2D.js';
 import { SplatGeometry } from './SplatGeometry.js';
 import { SplatScene } from './SplatScene.js';
 import { SplatTree } from '../splattree/SplatTree.js';
@@ -345,9 +346,15 @@ export class SplatMesh extends THREE.Mesh {
             this.lastBuildMaxSplatCount = 0;
             this.disposeMeshData();
             this.geometry = SplatGeometry.build(maxSplatCount);
-            this.material = SplatMaterial.build(this.dynamicMode, this.splatRenderMode, this.enableOptionalEffects, this.antialiased,
-                                                this.maxScreenSpaceSplatSize, this.splatScale, this.pointCloudModeEnabled,
-                                                this.minSphericalHarmonicsDegree);
+            if (this.splatRenderMode === SplatRenderMode.ThreeD) {
+                this.material = SplatMaterial3D.build(this.dynamicMode, this.enableOptionalEffects, this.antialiased,
+                                                      this.maxScreenSpaceSplatSize, this.splatScale, this.pointCloudModeEnabled,
+                                                      this.minSphericalHarmonicsDegree);
+            } else {
+                this.material = SplatMaterial2D.build(this.dynamicMode, this.enableOptionalEffects,
+                                                      this.splatScale, this.pointCloudModeEnabled, this.minSphericalHarmonicsDegree);
+            }
+
             const indexMaps = SplatMesh.buildSplatIndexMaps(splatBuffers);
             this.globalSplatIndexToLocalSplatIndexMap = indexMaps.localSplatIndexMap;
             this.globalSplatIndexToSceneIndexMap = indexMaps.sceneIndexMap;


### PR DESCRIPTION
- Support 2D Gaussian splatting scenes: https://surfsplatting.github.io/, activate with `Viewer` parameter `splatRenderMode: GaussianSplats3D.SplatRenderMode.TwoD`
- Fixed rendering bug with spherical harmonics in scenes with large number of splats
- Fixed scaling bug with spherical harmonics
- Properly apply scene opacity and visibility when scene is loaded
- Fixed bug where call to remove splat scene would never complete if there was only one splat scene loaded
- Fix double `dispose()` call in `Viewer.removeSplatScene()`
- Added `Viewer.removeSplatScenes()`