### PR TITLE
Manual render option

### DIFF
--- a/src/Viewer.js
+++ b/src/Viewer.js
@@ -186,6 +186,7 @@ export class Viewer {
             options.splatRenderMode = SplatRenderMode.ThreeD;
         }
         this.splatRenderMode = options.splatRenderMode;
+        this.manualRender = options.manualRender || false;
 
         this.onSplatMeshChangedCallback = null;
         this.createSplatMesh();
@@ -1541,6 +1542,7 @@ export class Viewer {
     render = function() {
 
         return function() {
+            if(this.manualRender) return
             if (!this.initialized || !this.splatRenderReady) return;
 
             const hasRenderables = (threeScene) => {


### PR DESCRIPTION
I'm working on a project where I am using a splat as the background of a web experience with other scene 3D geometry, I needed to be able to implement custom render process with different passes applied to the splat and the other scene elements independently.

I've added an option (manualRender) passed into the constructor that just disables the default render step.

If there isn't another way to already achieve this I thought it might be useful to our users.

Cheers!
Nick