### PR TITLE
Fix missing _axis variable

### DIFF
--- a/src/ArrowHelper.js
+++ b/src/ArrowHelper.js
@@ -1,5 +1,7 @@
 import * as THREE from 'three';
 
+const _axis = new THREE.Vector3();
+
 export class ArrowHelper extends THREE.Object3D {
 
     constructor(dir = new THREE.Vector3(0, 0, 1), origin = new THREE.Vector3(0, 0, 0), length = 1,


### PR DESCRIPTION
This piece of code uses uninitialized variable:

```
    setDirection( dir ) {
        if (dir.y > 0.99999) {
            this.quaternion.set(0, 0, 0, 1);
        } else if (dir.y < - 0.99999) {
            this.quaternion.set(1, 0, 0, 0);
        } else {
            _axis.set(dir.z, 0, -dir.x).normalize();
            const radians = Math.acos(dir.y);
            this.quaternion.setFromAxisAngle(_axis, radians);
        }
    }
```

I add a global constant to fix this, similar to this threejs example file: https://github.com/mrdoob/three.js/blob/dev/examples/jsm/utils/CameraUtils.js