### PR TITLE
fetchWithProgress: Do not return invalid data when status is not OK

### DIFF
--- a/src/Util.js
+++ b/src/Util.js
@@ -70,6 +70,14 @@ export const fetchWithProgress = function(path, onProgress, saveChunks = true) {
         rejectFunc = reject;
         fetch(path, { signal })
         .then(async (data) => {
+            if (!data.ok) {
+                const error_text = await data.text();
+                reject(new Error(
+                        `Fetch failed: ${data.status} ${data.statusText} ${error_text}`
+                ));
+                return;
+            }
+
             const reader = data.body.getReader();
             let bytesDownloaded = 0;
             let _fileSize = data.headers.get('Content-Length');


### PR DESCRIPTION
On a 404 error, my server returns some data (the error message page). This data is then interpreted as gaussian splats, which leads to weird errors.

Instead, just throw an explicit error.