### PR TITLE
Add the possibility to load a scene from file

### DIFF
--- a/src/Viewer.js
+++ b/src/Viewer.js
@@ -263,9 +263,9 @@ export class Viewer {
 
     createSplatMesh() {
         this.splatMesh = new SplatMesh(this.splatRenderMode, this.dynamicScene, this.enableOptionalEffects,
-                                       this.halfPrecisionCovariancesOnGPU, this.devicePixelRatio, this.gpuAcceleratedSort,
-                                       this.integerBasedSort, this.antialiased, this.maxScreenSpaceSplatSize, this.logLevel,
-                                       this.sphericalHarmonicsDegree);
+            this.halfPrecisionCovariancesOnGPU, this.devicePixelRatio, this.gpuAcceleratedSort,
+            this.integerBasedSort, this.antialiased, this.maxScreenSpaceSplatSize, this.logLevel,
+            this.sphericalHarmonicsDegree);
         this.splatMesh.frustumCulled = false;
         if (this.onSplatMeshChangedCallback) this.onSplatMeshChangedCallback();
     }
@@ -312,7 +312,7 @@ export class Viewer {
 
             this.perspectiveCamera = new THREE.PerspectiveCamera(THREE_CAMERA_FOV, renderDimensions.x / renderDimensions.y, 0.1, 1000);
             this.orthographicCamera = new THREE.OrthographicCamera(renderDimensions.x / -2, renderDimensions.x / 2,
-                                                                   renderDimensions.y / 2, renderDimensions.y / -2, 0.1, 1000 );
+                renderDimensions.y / 2, renderDimensions.y / -2, 0.1, 1000);
             this.camera = this.startInOrthographicMode ? this.orthographicCamera : this.perspectiveCamera;
             this.camera.position.copy(this.initialCameraPosition);
             this.camera.up.copy(this.cameraUp).normalize();
@@ -331,7 +331,7 @@ export class Viewer {
             });
             this.renderer.setPixelRatio(this.devicePixelRatio);
             this.renderer.autoClear = true;
-            this.renderer.setClearColor(new THREE.Color( 0x000000 ), 0.0);
+            this.renderer.setClearColor(new THREE.Color(0x000000), 0.0);
             this.renderer.setSize(renderDimensions.x, renderDimensions.y);
 
             this.resizeObserver = new ResizeObserver(() => {
@@ -443,23 +443,23 @@ export class Viewer {
                 case 'KeyG':
                     this.focalAdjustment += 0.02;
                     this.forceRenderNextFrame();
-                break;
+                    break;
                 case 'KeyF':
                     this.focalAdjustment -= 0.02;
                     this.forceRenderNextFrame();
-                break;
+                    break;
                 case 'ArrowLeft':
                     this.camera.up.transformDirection(tempMatrixLeft);
-                break;
+                    break;
                 case 'ArrowRight':
                     this.camera.up.transformDirection(tempMatrixRight);
-                break;
+                    break;
                 case 'KeyC':
                     this.showMeshCursor = !this.showMeshCursor;
-                break;
+                    break;
                 case 'KeyU':
                     this.showControlPlane = !this.showControlPlane;
-                break;
+                    break;
                 case 'KeyI':
                     this.showInfo = !this.showInfo;
                     if (this.showInfo) {
@@ -467,27 +467,27 @@ export class Viewer {
                     } else {
                         this.infoPanel.hide();
                     }
-                break;
+                    break;
                 case 'KeyO':
                     if (!this.usingExternalCamera) {
                         this.setOrthographicMode(!this.camera.isOrthographicCamera);
                     }
-                break;
+                    break;
                 case 'KeyP':
                     if (!this.usingExternalCamera) {
                         this.splatMesh.setPointCloudModeEnabled(!this.splatMesh.getPointCloudModeEnabled());
                     }
-                break;
+                    break;
                 case 'Equal':
                     if (!this.usingExternalCamera) {
                         this.splatMesh.setSplatScale(this.splatMesh.getSplatScale() + 0.05);
                     }
-                break;
+                    break;
                 case 'Minus':
                     if (!this.usingExternalCamera) {
                         this.splatMesh.setSplatScale(Math.max(this.splatMesh.getSplatScale() - 0.05, 0.0));
                     }
-                break;
+                    break;
             }
         };
 
@@ -630,9 +630,9 @@ export class Viewer {
                 this.splatMesh.updateTransforms();
                 this.getRenderDimensions(renderDimensions);
                 const focalLengthX = this.camera.projectionMatrix.elements[0] * 0.5 *
-                                     this.devicePixelRatio * renderDimensions.x;
+                    this.devicePixelRatio * renderDimensions.x;
                 const focalLengthY = this.camera.projectionMatrix.elements[5] * 0.5 *
-                                     this.devicePixelRatio * renderDimensions.y;
+                    this.devicePixelRatio * renderDimensions.y;
 
                 const focalMultiplier = this.camera.isOrthographicCamera ? (1.0 / this.devicePixelRatio) : 1.0;
                 const focalAdjustment = this.focalAdjustment * focalMultiplier;
@@ -640,7 +640,7 @@ export class Viewer {
 
                 this.adjustForWebXRStereo(renderDimensions);
                 this.splatMesh.updateUniforms(renderDimensions, focalLengthX * focalAdjustment, focalLengthY * focalAdjustment,
-                                              this.camera.isOrthographicCamera, this.camera.zoom || 1.0, inverseFocalAdjustment);
+                    this.camera.isOrthographicCamera, this.camera.zoom || 1.0, inverseFocalAdjustment);
             }
         };
 
@@ -658,7 +658,7 @@ export class Viewer {
 
     isLoadingOrUnloading() {
         return Object.keys(this.splatSceneDownloadPromises).length > 0 || this.splatSceneDownloadAndBuildPromise !== null ||
-                           this.splatSceneRemovalPromise !== null;
+            this.splatSceneRemovalPromise !== null;
     }
 
     isDisposingOrDisposed() {
@@ -784,16 +784,121 @@ export class Viewer {
                 'splatAlphaRemovalThreshold': options.splatAlphaRemovalThreshold,
             };
             return this.addSplatBuffers([splatBuffer], [addSplatBufferOptions],
-                                         finalBuild, firstBuild && showLoadingUI, showLoadingUI,
-                                         progressiveLoad, progressiveLoad).then(() => {
-                if (!progressiveLoad && options.onProgress) options.onProgress(100, '100%', LoaderStatus.Processing);
-                splatBuffersAddedUIUpdate(firstBuild, finalBuild);
-            });
+                finalBuild, firstBuild && showLoadingUI, showLoadingUI,
+                progressiveLoad, progressiveLoad).then(() => {
+                    if (!progressiveLoad && options.onProgress) options.onProgress(100, '100%', LoaderStatus.Processing);
+                    splatBuffersAddedUIUpdate(firstBuild, finalBuild);
+                });
         };
 
         const loadFunc = progressiveLoad ? this.downloadAndBuildSingleSplatSceneProgressiveLoad.bind(this) :
-                                           this.downloadAndBuildSingleSplatSceneStandardLoad.bind(this);
+            this.downloadAndBuildSingleSplatSceneStandardLoad.bind(this);
         return loadFunc(path, format, options.splatAlphaRemovalThreshold, buildSection.bind(this), onProgress, hideLoadingUI.bind(this));
+    }
+
+    /**
+     * Add a splat scene to the viewer and display any loading UI if appropriate.
+     * @param {File} file File containing the splats
+     * @param {object} options {
+     *         splatAlphaRemovalThreshold: Ignore any splats with an alpha less than the specified
+     *                                     value (valid range: 0 - 255), defaults to 1
+     *
+     *         showLoadingUI:         Display a loading spinner while the scene is loading, defaults to true
+     *
+     *         position (Array<number>):   Position of the scene, acts as an offset from its default position, defaults to [0, 0, 0]
+     *
+     *         rotation (Array<number>):   Rotation of the scene represented as a quaternion, defaults to [0, 0, 0, 1]
+     *
+     *         scale (Array<number>):      Scene's scale, defaults to [1, 1, 1]
+     *
+     *         onProgress:                 Function to be called as file data are received, or other processing occurs
+     *
+     * }
+     * @return {AbortablePromise}
+    **/
+
+    addSplatSceneFromFile(file, options = {}) {
+        if (this.isLoadingOrUnloading()) {
+            throw new Error('Cannot add splat scene while another load or unload is already in progress.');
+        }
+
+        if (this.isDisposingOrDisposed()) {
+            throw new Error('Cannot add splat scene after dispose() is called.');
+        }
+
+        if (options.progressiveLoad && this.splatMesh.scenes && this.splatMesh.scenes.length > 0) {
+            console.log('addSplatScene(): "progressiveLoad" option ignore because there are multiple splat scenes');
+            options.progressiveLoad = false;
+        }
+
+
+        // TODO: check if the file is a File
+
+        const format = (options.format !== undefined && options.format !== null) ? options.format : sceneFormatFromPath(path);
+        const progressiveLoad = Viewer.isProgressivelyLoadable(format) && options.progressiveLoad;
+        const showLoadingUI = (options.showLoadingUI !== undefined && options.showLoadingUI !== null) ? options.showLoadingUI : true;
+
+        let loadingUITaskId = null;
+        if (showLoadingUI) {
+            this.loadingSpinner.removeAllTasks();
+            loadingUITaskId = this.loadingSpinner.addTask(`Loading ${file.fileName} ...`);
+        }
+        const hideLoadingUI = () => {
+            this.loadingProgressBar.hide();
+            this.loadingSpinner.removeAllTasks();
+        };
+
+        const onProgressUIUpdate = (percentComplete, percentCompleteLabel, loaderStatus) => {
+            if (showLoadingUI && loaderStatus === LoaderStatus.Processing) {
+                this.loadingSpinner.setMessageForTask(loadingUITaskId, `Processing splats : ${percentCompleteLabel}`);
+            }
+        };
+
+        let downloadDone = false;
+        let downloadedPercentage = 0;
+        const splatBuffersAddedUIUpdate = (firstBuild, finalBuild) => {
+            if (showLoadingUI) {
+                if (firstBuild && progressiveLoad || finalBuild && !progressiveLoad) {
+                    this.loadingSpinner.removeTask(loadingUITaskId);
+                    if (!finalBuild && !downloadDone) this.loadingProgressBar.show();
+                }
+                if (progressiveLoad) {
+                    if (finalBuild) {
+                        downloadDone = true;
+                        this.loadingProgressBar.hide();
+                    } else {
+                        this.loadingProgressBar.setProgress(downloadedPercentage);
+                    }
+                }
+            }
+        };
+
+        const onProgress = (percentComplete, percentCompleteLabel, loaderStatus) => {
+            downloadedPercentage = percentComplete;
+            onProgressUIUpdate(percentComplete, percentCompleteLabel, loaderStatus);
+            if (options.onProgress) options.onProgress(percentComplete, percentCompleteLabel, loaderStatus);
+        };
+
+        const buildSection = (splatBuffer, firstBuild, finalBuild) => {
+            if (!progressiveLoad && options.onProgress) options.onProgress(0, '0%', LoaderStatus.Processing);
+            const addSplatBufferOptions = {
+                'rotation': options.rotation || options.orientation,
+                'position': options.position,
+                'scale': options.scale,
+                'splatAlphaRemovalThreshold': options.splatAlphaRemovalThreshold,
+            };
+            return this.addSplatBuffers([splatBuffer], [addSplatBufferOptions],
+                finalBuild, firstBuild && showLoadingUI, showLoadingUI,
+                progressiveLoad, progressiveLoad).then(() => {
+                    if (!progressiveLoad && options.onProgress) options.onProgress(100, '100%', LoaderStatus.Processing);
+                    splatBuffersAddedUIUpdate(firstBuild, finalBuild);
+                });
+
+        };
+
+        // const loadFunc = progressiveLoad ? this.downloadAndBuildSingleSplatSceneProgressiveLoad.bind(this) :
+        const loadFunc = this.buildSingleSplatSceneFromFile.bind(this)
+        return loadFunc(file, format, options.splatAlphaRemovalThreshold, buildSection.bind(this), onProgress, hideLoadingUI.bind(this));
     }
 
     /**
@@ -811,7 +916,7 @@ export class Viewer {
     downloadAndBuildSingleSplatSceneStandardLoad(path, format, splatAlphaRemovalThreshold, buildFunc, onProgress, onException) {
 
         const downloadPromise = this.downloadSplatSceneToSplatBuffer(path, splatAlphaRemovalThreshold,
-                                                                     onProgress, false, undefined, format);
+            onProgress, false, undefined, format);
         const downloadAndBuildPromise = abortablePromiseWithExtractedComponents(downloadPromise.abortHandler);
 
         downloadPromise.then((splatBuffer) => {
@@ -821,18 +926,70 @@ export class Viewer {
                 this.clearSplatSceneDownloadAndBuildPromise();
             });
         })
-        .catch((e) => {
-            if (onException) onException();
-            this.clearSplatSceneDownloadAndBuildPromise();
-            this.removeSplatSceneDownloadPromise(downloadPromise);
-            const error = (e instanceof AbortedPromiseError) ? e : new Error(`Viewer::addSplatScene -> Could not load file ${path}`);
-            downloadAndBuildPromise.reject(error);
-        });
+            .catch((e) => {
+                if (onException) onException();
+                this.clearSplatSceneDownloadAndBuildPromise();
+                this.removeSplatSceneDownloadPromise(downloadPromise);
+                const error = (e instanceof AbortedPromiseError) ? e : new Error(`Viewer::addSplatScene -> Could not load file ${path}`);
+                downloadAndBuildPromise.reject(error);
+            });
 
         this.addSplatSceneDownloadPromise(downloadPromise);
         this.setSplatSceneDownloadAndBuildPromise(downloadAndBuildPromise.promise);
 
         return downloadAndBuildPromise.promise;
+    }
+
+    /**
+     * Load a single splat scene from a file, convert to splat buffer and then rebuild the viewer's splat mesh
+     * by calling 'buildFunc' -- all before displaying the scene. Also sets/clears relevant instance synchronization objects,
+     * and calls appropriate functions on success or failure.
+     * @param {File} file File containing the splats
+     * @param {SceneFormat} format Format of the splat scene file
+     * @param {number} splatAlphaRemovalThreshold Ignore any splats with an alpha less than the specified value (valid range: 0 - 255)
+     * @param {function} buildFunc Function to build the viewer's splat mesh with the downloaded splat buffer
+     * @param {function} onProgress Function to be called as file data are received, or other processing occurs
+     * @param {function} onException Function to be called when exception occurs
+     * @return {AbortablePromise}
+     */
+    buildSingleSplatSceneFromFile(file, format, splatAlphaRemovalThreshold, buildFunc, onProgress, onException) {
+        // Build a promise that read the file data, and call onException on error
+        const loadFileDataPromise = new Promise((resolve, _reject) => {
+            const reader = new FileReader();
+            reader.onload = (_loadEvent) => {
+                if (reader.readyState == FileReader.DONE) {
+                    resolve(reader.result);
+                }
+            }
+            reader.onerror = onException; // reject is not use, the exception are direclty handle by the onExpection callback
+            reader.readAsArrayBuffer(file);
+        })
+
+        const loadAndBuildPromise = loadFileDataPromise
+            .then((fileData) => {
+                // Read the data from the file
+                let buildScenePromise = this.loadSplatSceneFromFileToSplatBuffer(fileData, splatAlphaRemovalThreshold, onProgress, false, undefined, format);
+                // abortPromise = abortablePromiseWithExtractedComponents(loadFileDataPromise.abortHandler);
+                return buildScenePromise;
+            })
+            .then((splatBuffer) => {
+                console.log('splatBuffer')
+                // Construct a scene from the splatBuffer
+                this.removeSplatSceneDownloadPromise(loadFileDataPromise);
+                return buildFunc(splatBuffer, true, true).then(() => {
+                    // abortPromise.resolve();
+                    this.clearSplatSceneDownloadAndBuildPromise();
+                });
+            })
+            .catch((e) => {
+                console.log(e)
+                if (onException) onException();
+                this.clearSplatSceneDownloadAndBuildPromise();
+                const error = (e instanceof AbortedPromiseError) ? e : new Error(`Viewer::addSplatScene -> Could not load file ${file.fileName}`);
+                // abortPromise.reject(error);
+            });
+
+        return loadAndBuildPromise;
     }
 
     /**
@@ -848,7 +1005,7 @@ export class Viewer {
      * @return {AbortablePromise}
      */
     downloadAndBuildSingleSplatSceneProgressiveLoad(path, format, splatAlphaRemovalThreshold, buildFunc,
-                                                    onDownloadProgress, onDownloadException) {
+        onDownloadProgress, onDownloadException) {
         let progressiveLoadedSectionBuildCount = 0;
         let progressiveLoadedSectionBuilding = false;
         const queuedProgressiveLoadSectionBuilds = [];
@@ -860,19 +1017,19 @@ export class Viewer {
                 progressiveLoadedSectionBuilding = true;
                 const queuedBuild = queuedProgressiveLoadSectionBuilds.shift();
                 buildFunc(queuedBuild.splatBuffer, queuedBuild.firstBuild, queuedBuild.finalBuild)
-                .then(() => {
-                    progressiveLoadedSectionBuilding = false;
-                    if (queuedBuild.firstBuild) {
-                        progressiveLoadFirstSectionBuildPromise.reject = null;
-                        progressiveLoadFirstSectionBuildPromise.resolve();
-                    } else if (queuedBuild.finalBuild) {
-                        splatSceneDownloadAndBuildPromise.resolve();
-                        this.clearSplatSceneDownloadAndBuildPromise();
-                    }
-                    if (queuedProgressiveLoadSectionBuilds.length > 0) {
-                        delayedExecute(() => checkAndBuildProgressiveLoadSections());
-                    }
-                });
+                    .then(() => {
+                        progressiveLoadedSectionBuilding = false;
+                        if (queuedBuild.firstBuild) {
+                            progressiveLoadFirstSectionBuildPromise.reject = null;
+                            progressiveLoadFirstSectionBuildPromise.resolve();
+                        } else if (queuedBuild.finalBuild) {
+                            splatSceneDownloadAndBuildPromise.resolve();
+                            this.clearSplatSceneDownloadAndBuildPromise();
+                        }
+                        if (queuedProgressiveLoadSectionBuilds.length > 0) {
+                            delayedExecute(() => checkAndBuildProgressiveLoadSections());
+                        }
+                    });
             }
         };
 
@@ -892,7 +1049,7 @@ export class Viewer {
         };
 
         let splatSceneDownloadPromise = this.downloadSplatSceneToSplatBuffer(path, splatAlphaRemovalThreshold, onDownloadProgress, true,
-                                                                             onProgressiveLoadSectionProgress, format);
+            onProgressiveLoadSectionProgress, format);
 
         const progressiveLoadFirstSectionBuildPromise = abortablePromiseWithExtractedComponents(splatSceneDownloadPromise.abortHandler);
         const splatSceneDownloadAndBuildPromise = abortablePromiseWithExtractedComponents();
@@ -903,13 +1060,13 @@ export class Viewer {
         splatSceneDownloadPromise.then(() => {
             this.removeSplatSceneDownloadPromise(splatSceneDownloadPromise);
         })
-        .catch((e) => {
-            this.clearSplatSceneDownloadAndBuildPromise();
-            this.removeSplatSceneDownloadPromise(splatSceneDownloadPromise);
-            const error = (e instanceof AbortedPromiseError) ? e : new Error(`Viewer::addSplatScene -> Could not load one or more scenes`);
-            progressiveLoadFirstSectionBuildPromise.reject(error);
-            if (onDownloadException) onDownloadException(error);
-        });
+            .catch((e) => {
+                this.clearSplatSceneDownloadAndBuildPromise();
+                this.removeSplatSceneDownloadPromise(splatSceneDownloadPromise);
+                const error = (e instanceof AbortedPromiseError) ? e : new Error(`Viewer::addSplatScene -> Could not load one or more scenes`);
+                progressiveLoadFirstSectionBuildPromise.reject(error);
+                if (onDownloadException) onDownloadException(error);
+            });
 
         return progressiveLoadFirstSectionBuildPromise.promise;
     }
@@ -961,7 +1118,7 @@ export class Viewer {
             if (showLoadingUI) {
                 if (loaderStatus === LoaderStatus.Downloading) {
                     this.loadingSpinner.setMessageForTask(loadingUITaskId, totalPercent == 100 ?
-                                                          `Download complete!` : `Downloading: ${percentLabel}`);
+                        `Download complete!` : `Downloading: ${percentLabel}`);
                 }
             }
             if (onProgress) onProgress(totalPercent, percentLabel, loaderStatus);
@@ -973,32 +1130,32 @@ export class Viewer {
             const options = sceneOptions[i];
             const format = (options.format !== undefined && options.format !== null) ? options.format : sceneFormatFromPath(options.path);
             const baseDownloadPromise = this.downloadSplatSceneToSplatBuffer(options.path, options.splatAlphaRemovalThreshold,
-                                                                             onLoadProgress.bind(this, i), false, undefined, format);
+                onLoadProgress.bind(this, i), false, undefined, format);
             baseDownloadPromises.push(baseDownloadPromise);
             nativeDownloadPromises.push(baseDownloadPromise.promise);
         }
 
         const downloadAndBuildPromise = new AbortablePromise((resolve, reject) => {
             Promise.all(nativeDownloadPromises)
-            .then((splatBuffers) => {
-                if (showLoadingUI) this.loadingSpinner.removeTask(loadingUITaskId);
-                if (onProgress) onProgress(0, '0%', LoaderStatus.Processing);
-                this.addSplatBuffers(splatBuffers, sceneOptions, true, showLoadingUI, showLoadingUI, false, false).then(() => {
-                    if (onProgress) onProgress(100, '100%', LoaderStatus.Processing);
+                .then((splatBuffers) => {
+                    if (showLoadingUI) this.loadingSpinner.removeTask(loadingUITaskId);
+                    if (onProgress) onProgress(0, '0%', LoaderStatus.Processing);
+                    this.addSplatBuffers(splatBuffers, sceneOptions, true, showLoadingUI, showLoadingUI, false, false).then(() => {
+                        if (onProgress) onProgress(100, '100%', LoaderStatus.Processing);
+                        this.clearSplatSceneDownloadAndBuildPromise();
+                        resolve();
+                    });
+                })
+                .catch((e) => {
+                    if (showLoadingUI) this.loadingSpinner.removeTask(loadingUITaskId);
                     this.clearSplatSceneDownloadAndBuildPromise();
-                    resolve();
+                    const error = (e instanceof AbortedPromiseError) ? e :
+                        new Error(`Viewer::addSplatScenes -> Could not load one or more splat scenes.`);
+                    reject(error);
+                })
+                .finally(() => {
+                    this.removeSplatSceneDownloadPromise(downloadAndBuildPromise);
                 });
-            })
-            .catch((e) => {
-                if (showLoadingUI) this.loadingSpinner.removeTask(loadingUITaskId);
-                this.clearSplatSceneDownloadAndBuildPromise();
-                const error = (e instanceof AbortedPromiseError) ? e :
-                               new Error(`Viewer::addSplatScenes -> Could not load one or more splat scenes.`);
-                reject(error);
-            })
-            .finally(() => {
-                this.removeSplatSceneDownloadPromise(downloadAndBuildPromise);
-            });
         }, (reason) => {
             for (let baseDownloadPromise of baseDownloadPromises) {
                 baseDownloadPromise.abort(reason);
@@ -1022,18 +1179,43 @@ export class Viewer {
      * @return {AbortablePromise}
      */
     downloadSplatSceneToSplatBuffer(path, splatAlphaRemovalThreshold = 1, onProgress = undefined,
-                                    progressiveBuild = false, onSectionBuilt = undefined, format) {
+        progressiveBuild = false, onSectionBuilt = undefined, format) {
         if (format === SceneFormat.Splat) {
             return SplatLoader.loadFromURL(path, onProgress, progressiveBuild,
-                                           onSectionBuilt, splatAlphaRemovalThreshold, 0, false);
+                onSectionBuilt, splatAlphaRemovalThreshold, 0, false);
         } else if (format === SceneFormat.KSplat) {
             return KSplatLoader.loadFromURL(path, onProgress, progressiveBuild, onSectionBuilt);
         } else if (format === SceneFormat.Ply) {
             return PlyLoader.loadFromURL(path, onProgress, progressiveBuild, onSectionBuilt,
-                                         splatAlphaRemovalThreshold, this.plyInMemoryCompressionLevel, this.sphericalHarmonicsDegree);
+                splatAlphaRemovalThreshold, this.plyInMemoryCompressionLevel, this.sphericalHarmonicsDegree);
         }
 
         throw new Error(`Viewer::downloadSplatSceneToSplatBuffer -> File format not supported: ${path}`);
+    }
+
+    /**
+     * Load a splat scene from an ArrayBuffer and convert to SplatBuffer instance.
+     * @param {ArrayBuffer} fileData The data of the file
+     * @param {number} splatAlphaRemovalThreshold Ignore any splats with an alpha less than the specified
+     *                                            value (valid range: 0 - 255), defaults to 1
+     *
+     * @param {function} onProgress Function to be called as file data are received
+     * @param {boolean} progressiveBuild Construct file sections into splat buffers as they are downloaded
+     * @param {function} onSectionBuilt Function to be called when new section is added to the file
+     * @param {string} format File format of the scene
+     * @return {AbortablePromise}
+     */
+    loadSplatSceneFromFileToSplatBuffer(fileData, splatAlphaRemovalThreshold = 1, onProgress = undefined,
+        progressiveBuild = false, onSectionBuilt = undefined, format) {
+        if (format === SceneFormat.Splat) {
+            return SplatLoader.loadFromFileData(fileData, splatAlphaRemovalThreshold, 0, false);
+        } else if (format === SceneFormat.KSplat) {
+            return KSplatLoader.loadFromFileData(fileData);
+        } else if (format === SceneFormat.Ply) {
+            return PlyLoader.loadFromFileData(fileData, splatAlphaRemovalThreshold, this.plyInMemoryCompressionLevel, this.sphericalHarmonicsDegree);
+        }
+
+        throw new Error(`Viewer::LoadSplatSceneFromFileToSplatBuffer -> File format not supported: ${path}`);
     }
 
     static isProgressivelyLoadable(format) {
@@ -1047,8 +1229,8 @@ export class Viewer {
     addSplatBuffers = function() {
 
         return function(splatBuffers, splatBufferOptions = [], finalBuild = true, showLoadingUI = true,
-                        showLoadingUIForSplatTreeBuild = true, replaceExisting = false,
-                        enableRenderBeforeFirstSort = false, preserveVisibleRegion = true) {
+            showLoadingUIForSplatTreeBuild = true, replaceExisting = false,
+            enableRenderBeforeFirstSort = false, preserveVisibleRegion = true) {
 
             if (this.isDisposingOrDisposed()) return Promise.resolve();
 
@@ -1110,12 +1292,12 @@ export class Viewer {
                         resolve();
                     } else {
                         const buildResults = this.addSplatBuffersToMesh(splatBuffers, splatBufferOptions, finalBuild,
-                                                                        showLoadingUIForSplatTreeBuild, replaceExisting,
-                                                                        preserveVisibleRegion);
+                            showLoadingUIForSplatTreeBuild, replaceExisting,
+                            preserveVisibleRegion);
                         const maxSplatCount = this.splatMesh.getMaxSplatCount();
                         if (this.sortWorker && this.sortWorker.maxSplatCount !== maxSplatCount) this.disposeSortWorker();
                         const sortWorkerSetupPromise = (!this.sortWorker && maxSplatCount > 0) ?
-                                                         this.setupSortWorker(this.splatMesh) : Promise.resolve();
+                            this.setupSortWorker(this.splatMesh) : Promise.resolve();
                         sortWorkerSetupPromise.then(() => {
                             finish(buildResults, resolve);
                         });
@@ -1151,7 +1333,7 @@ export class Viewer {
         let splatOptimizingTaskId;
 
         return function(splatBuffers, splatBufferOptions, finalBuild = true, showLoadingUIForSplatTreeBuild = false,
-                        replaceExisting = false, preserveVisibleRegion = true) {
+            replaceExisting = false, preserveVisibleRegion = true) {
             if (this.isDisposingOrDisposed()) return;
             let allSplatBuffers = [];
             let allSplatBufferOptions = [];
@@ -1180,7 +1362,7 @@ export class Viewer {
                 }
             };
             const buildResults = this.splatMesh.build(allSplatBuffers, allSplatBufferOptions, true, finalBuild, onSplatTreeIndexesUpload,
-                                                      onSplatTreeReady, preserveVisibleRegion);
+                onSplatTreeReady, preserveVisibleRegion);
             if (finalBuild && this.freeIntermediateSplatData) this.splatMesh.freeIntermediateSplatData();
             return buildResults;
         };
@@ -1199,7 +1381,7 @@ export class Viewer {
             const splatCount = splatMesh.getSplatCount();
             const maxSplatCount = splatMesh.getMaxSplatCount();
             this.sortWorker = createSortWorker(maxSplatCount, this.sharedMemoryForWorkers, this.enableSIMDInSort,
-                                               this.integerBasedSort, this.splatMesh.dynamicMode);
+                this.integerBasedSort, this.splatMesh.dynamicMode);
             this.sortWorker.onmessage = (e) => {
                 if (e.data.sortDone) {
                     this.sortRunning = false;
@@ -1225,14 +1407,14 @@ export class Viewer {
                     if (this.logLevel >= LogLevel.Info) console.log('Sorting web worker WASM setup complete.');
                     if (this.sharedMemoryForWorkers) {
                         this.sortWorkerSortedIndexes = new Uint32Array(e.data.sortedIndexesBuffer,
-                                                                       e.data.sortedIndexesOffset, maxSplatCount);
+                            e.data.sortedIndexesOffset, maxSplatCount);
                         this.sortWorkerIndexesToSort = new Uint32Array(e.data.indexesToSortBuffer,
-                                                                       e.data.indexesToSortOffset, maxSplatCount);
+                            e.data.indexesToSortOffset, maxSplatCount);
                         this.sortWorkerPrecomputedDistances = new DistancesArrayType(e.data.precomputedDistancesBuffer,
-                                                                                     e.data.precomputedDistancesOffset,
-                                                                                     maxSplatCount);
-                         this.sortWorkerTransforms = new Float32Array(e.data.transformsBuffer,
-                                                                      e.data.transformsOffset, Constants.MaxScenes * 16);
+                            e.data.precomputedDistancesOffset,
+                            maxSplatCount);
+                        this.sortWorkerTransforms = new Float32Array(e.data.transformsBuffer,
+                            e.data.transformsOffset, Constants.MaxScenes * 16);
                     } else {
                         this.sortWorkerIndexesToSort = new Uint32Array(maxSplatCount);
                         this.sortWorkerPrecomputedDistances = new DistancesArrayType(maxSplatCount);
@@ -1343,33 +1525,33 @@ export class Viewer {
                 this.sceneRevealMode = SceneRevealMode.Instant;
                 this.createSplatMesh();
                 this.addSplatBuffers(savedSplatBuffers, savedSceneOptions, true, false, true)
-                .then(() => {
-                    if (checkForEarlyExit()) return;
-                    checkAndHideLoadingUI();
-                    this.splatMesh.scenes.forEach((scene, index) => {
-                        scene.position.copy(savedSceneTransformComponents[index].position);
-                        scene.quaternion.copy(savedSceneTransformComponents[index].quaternion);
-                        scene.scale.copy(savedSceneTransformComponents[index].scale);
-                    });
-                    this.splatMesh.updateTransforms();
-                    this.splatRenderReady = false;
-
-                    this.runSplatSort(true)
                     .then(() => {
-                        if (checkForEarlyExit()) {
-                            this.splatRenderReady = true;
-                            return;
-                        }
-                        sortPromise = this.sortPromise || Promise.resolve();
-                        sortPromise.then(() => {
-                            this.splatRenderReady = true;
-                            onDone();
+                        if (checkForEarlyExit()) return;
+                        checkAndHideLoadingUI();
+                        this.splatMesh.scenes.forEach((scene, index) => {
+                            scene.position.copy(savedSceneTransformComponents[index].position);
+                            scene.quaternion.copy(savedSceneTransformComponents[index].quaternion);
+                            scene.scale.copy(savedSceneTransformComponents[index].scale);
                         });
+                        this.splatMesh.updateTransforms();
+                        this.splatRenderReady = false;
+
+                        this.runSplatSort(true)
+                            .then(() => {
+                                if (checkForEarlyExit()) {
+                                    this.splatRenderReady = true;
+                                    return;
+                                }
+                                sortPromise = this.sortPromise || Promise.resolve();
+                                sortPromise.then(() => {
+                                    this.splatRenderReady = true;
+                                    onDone();
+                                });
+                            });
+                    })
+                    .catch((e) => {
+                        onDone(e);
                     });
-                })
-                .catch((e) => {
-                    onDone(e);
-                });
             });
         });
 
@@ -1513,16 +1695,16 @@ export class Viewer {
                 const cp = this.camera.position;
                 const co = this.camera.quaternion;
                 cameraChanged = Math.abs(cp.x - lastCameraPosition.x) > changeEpsilon ||
-                                Math.abs(cp.y - lastCameraPosition.y) > changeEpsilon ||
-                                Math.abs(cp.z - lastCameraPosition.z) > changeEpsilon ||
-                                Math.abs(co.x - lastCameraOrientation.x) > changeEpsilon ||
-                                Math.abs(co.y - lastCameraOrientation.y) > changeEpsilon ||
-                                Math.abs(co.z - lastCameraOrientation.z) > changeEpsilon ||
-                                Math.abs(co.w - lastCameraOrientation.w) > changeEpsilon;
+                    Math.abs(cp.y - lastCameraPosition.y) > changeEpsilon ||
+                    Math.abs(cp.z - lastCameraPosition.z) > changeEpsilon ||
+                    Math.abs(co.x - lastCameraOrientation.x) > changeEpsilon ||
+                    Math.abs(co.y - lastCameraOrientation.y) > changeEpsilon ||
+                    Math.abs(co.z - lastCameraOrientation.z) > changeEpsilon ||
+                    Math.abs(co.w - lastCameraOrientation.w) > changeEpsilon;
             }
 
             shouldRender = this.renderMode !== RenderMode.Never && (renderCount === 0 || this.splatMesh.visibleRegionChanging ||
-                           cameraChanged || this.renderMode === RenderMode.Always || this.dynamicMode === true || this.renderNextFrame);
+                cameraChanged || this.renderMode === RenderMode.Always || this.dynamicMode === true || this.renderNextFrame);
 
             if (this.camera) {
                 lastCameraPosition.copy(this.camera.position);
@@ -1750,10 +1932,10 @@ export class Viewer {
             const meshCursorPosition = this.showMeshCursor ? this.sceneHelper.meshCursor.position : null;
             const splatRenderCountPct = splatCount > 0 ? this.splatRenderCount / splatCount * 100 : 0;
             this.infoPanel.update(renderDimensions, this.camera.position, cameraLookAtPosition,
-                                  this.camera.up, this.camera.isOrthographicCamera, meshCursorPosition,
-                                  this.currentFPS || 'N/A', splatCount, this.splatRenderCount, splatRenderCountPct,
-                                  this.lastSortTime, this.focalAdjustment, this.splatMesh.getSplatScale(),
-                                  this.splatMesh.getPointCloudModeEnabled());
+                this.camera.up, this.camera.isOrthographicCamera, meshCursorPosition,
+                this.currentFPS || 'N/A', splatCount, this.splatRenderCount, splatRenderCountPct,
+                this.lastSortTime, this.focalAdjustment, this.splatMesh.getSplatScale(),
+                this.splatMesh.getPointCloudModeEnabled());
         };
 
     }();
@@ -1976,7 +2158,7 @@ export class Viewer {
                     const windowSizeInts = node.data.indexes.length;
                     const windowSizeBytes = windowSizeInts * Constants.BytesPerInt;
                     let destView = new Uint32Array(this.sortWorkerIndexesToSort.buffer,
-                                                   currentByteOffset - windowSizeBytes, windowSizeInts);
+                        currentByteOffset - windowSizeBytes, windowSizeInts);
                     destView.set(node.data.indexes);
                     currentByteOffset -= windowSizeBytes;
                 }

--- a/src/Viewer.js
+++ b/src/Viewer.js
@@ -263,9 +263,9 @@ export class Viewer {
 
     createSplatMesh() {
         this.splatMesh = new SplatMesh(this.splatRenderMode, this.dynamicScene, this.enableOptionalEffects,
-            this.halfPrecisionCovariancesOnGPU, this.devicePixelRatio, this.gpuAcceleratedSort,
-            this.integerBasedSort, this.antialiased, this.maxScreenSpaceSplatSize, this.logLevel,
-            this.sphericalHarmonicsDegree);
+                                       this.halfPrecisionCovariancesOnGPU, this.devicePixelRatio, this.gpuAcceleratedSort,
+                                       this.integerBasedSort, this.antialiased, this.maxScreenSpaceSplatSize, this.logLevel,
+                                       this.sphericalHarmonicsDegree);
         this.splatMesh.frustumCulled = false;
         if (this.onSplatMeshChangedCallback) this.onSplatMeshChangedCallback();
     }
@@ -312,7 +312,7 @@ export class Viewer {
 
             this.perspectiveCamera = new THREE.PerspectiveCamera(THREE_CAMERA_FOV, renderDimensions.x / renderDimensions.y, 0.1, 1000);
             this.orthographicCamera = new THREE.OrthographicCamera(renderDimensions.x / -2, renderDimensions.x / 2,
-                renderDimensions.y / 2, renderDimensions.y / -2, 0.1, 1000);
+                                                                   renderDimensions.y / 2, renderDimensions.y / -2, 0.1, 1000 );
             this.camera = this.startInOrthographicMode ? this.orthographicCamera : this.perspectiveCamera;
             this.camera.position.copy(this.initialCameraPosition);
             this.camera.up.copy(this.cameraUp).normalize();
@@ -331,7 +331,7 @@ export class Viewer {
             });
             this.renderer.setPixelRatio(this.devicePixelRatio);
             this.renderer.autoClear = true;
-            this.renderer.setClearColor(new THREE.Color(0x000000), 0.0);
+            this.renderer.setClearColor(new THREE.Color( 0x000000 ), 0.0);
             this.renderer.setSize(renderDimensions.x, renderDimensions.y);
 
             this.resizeObserver = new ResizeObserver(() => {
@@ -443,23 +443,23 @@ export class Viewer {
                 case 'KeyG':
                     this.focalAdjustment += 0.02;
                     this.forceRenderNextFrame();
-                    break;
+                break;
                 case 'KeyF':
                     this.focalAdjustment -= 0.02;
                     this.forceRenderNextFrame();
-                    break;
+                break;
                 case 'ArrowLeft':
                     this.camera.up.transformDirection(tempMatrixLeft);
-                    break;
+                break;
                 case 'ArrowRight':
                     this.camera.up.transformDirection(tempMatrixRight);
-                    break;
+                break;
                 case 'KeyC':
                     this.showMeshCursor = !this.showMeshCursor;
-                    break;
+                break;
                 case 'KeyU':
                     this.showControlPlane = !this.showControlPlane;
-                    break;
+                break;
                 case 'KeyI':
                     this.showInfo = !this.showInfo;
                     if (this.showInfo) {
@@ -467,27 +467,27 @@ export class Viewer {
                     } else {
                         this.infoPanel.hide();
                     }
-                    break;
+                break;
                 case 'KeyO':
                     if (!this.usingExternalCamera) {
                         this.setOrthographicMode(!this.camera.isOrthographicCamera);
                     }
-                    break;
+                break;
                 case 'KeyP':
                     if (!this.usingExternalCamera) {
                         this.splatMesh.setPointCloudModeEnabled(!this.splatMesh.getPointCloudModeEnabled());
                     }
-                    break;
+                break;
                 case 'Equal':
                     if (!this.usingExternalCamera) {
                         this.splatMesh.setSplatScale(this.splatMesh.getSplatScale() + 0.05);
                     }
-                    break;
+                break;
                 case 'Minus':
                     if (!this.usingExternalCamera) {
                         this.splatMesh.setSplatScale(Math.max(this.splatMesh.getSplatScale() - 0.05, 0.0));
                     }
-                    break;
+                break;
             }
         };
 
@@ -630,9 +630,9 @@ export class Viewer {
                 this.splatMesh.updateTransforms();
                 this.getRenderDimensions(renderDimensions);
                 const focalLengthX = this.camera.projectionMatrix.elements[0] * 0.5 *
-                    this.devicePixelRatio * renderDimensions.x;
+                                     this.devicePixelRatio * renderDimensions.x;
                 const focalLengthY = this.camera.projectionMatrix.elements[5] * 0.5 *
-                    this.devicePixelRatio * renderDimensions.y;
+                                     this.devicePixelRatio * renderDimensions.y;
 
                 const focalMultiplier = this.camera.isOrthographicCamera ? (1.0 / this.devicePixelRatio) : 1.0;
                 const focalAdjustment = this.focalAdjustment * focalMultiplier;
@@ -640,7 +640,7 @@ export class Viewer {
 
                 this.adjustForWebXRStereo(renderDimensions);
                 this.splatMesh.updateUniforms(renderDimensions, focalLengthX * focalAdjustment, focalLengthY * focalAdjustment,
-                    this.camera.isOrthographicCamera, this.camera.zoom || 1.0, inverseFocalAdjustment);
+                                              this.camera.isOrthographicCamera, this.camera.zoom || 1.0, inverseFocalAdjustment);
             }
         };
 
@@ -658,7 +658,7 @@ export class Viewer {
 
     isLoadingOrUnloading() {
         return Object.keys(this.splatSceneDownloadPromises).length > 0 || this.splatSceneDownloadAndBuildPromise !== null ||
-            this.splatSceneRemovalPromise !== null;
+                           this.splatSceneRemovalPromise !== null;
     }
 
     isDisposingOrDisposed() {
@@ -784,20 +784,20 @@ export class Viewer {
                 'splatAlphaRemovalThreshold': options.splatAlphaRemovalThreshold,
             };
             return this.addSplatBuffers([splatBuffer], [addSplatBufferOptions],
-                finalBuild, firstBuild && showLoadingUI, showLoadingUI,
-                progressiveLoad, progressiveLoad).then(() => {
-                    if (!progressiveLoad && options.onProgress) options.onProgress(100, '100%', LoaderStatus.Processing);
-                    splatBuffersAddedUIUpdate(firstBuild, finalBuild);
-                });
+                                         finalBuild, firstBuild && showLoadingUI, showLoadingUI,
+                                         progressiveLoad, progressiveLoad).then(() => {
+                if (!progressiveLoad && options.onProgress) options.onProgress(100, '100%', LoaderStatus.Processing);
+                splatBuffersAddedUIUpdate(firstBuild, finalBuild);
+            });
         };
 
         const loadFunc = progressiveLoad ? this.downloadAndBuildSingleSplatSceneProgressiveLoad.bind(this) :
-            this.downloadAndBuildSingleSplatSceneStandardLoad.bind(this);
+                                           this.downloadAndBuildSingleSplatSceneStandardLoad.bind(this);
         return loadFunc(path, format, options.splatAlphaRemovalThreshold, buildSection.bind(this), onProgress, hideLoadingUI.bind(this));
     }
 
     /**
-     * Add a splat scene to the viewer and display any loading UI if appropriate.
+     * Add a splat scene to the viewer from a file and display any loading UI if appropriate.
      * @param {File} file File containing the splats
      * @param {object} options {
      *         splatAlphaRemovalThreshold: Ignore any splats with an alpha less than the specified
@@ -815,7 +815,7 @@ export class Viewer {
      *
      * }
      * @return {AbortablePromise}
-    **/
+     **/
 
     addSplatSceneFromFile(file, options = {}) {
         if (this.isLoadingOrUnloading()) {
@@ -890,9 +890,9 @@ export class Viewer {
             return this.addSplatBuffers([splatBuffer], [addSplatBufferOptions],
                 finalBuild, firstBuild && showLoadingUI, showLoadingUI,
                 progressiveLoad, progressiveLoad).then(() => {
-                    if (!progressiveLoad && options.onProgress) options.onProgress(100, '100%', LoaderStatus.Processing);
-                    splatBuffersAddedUIUpdate(firstBuild, finalBuild);
-                });
+                if (!progressiveLoad && options.onProgress) options.onProgress(100, '100%', LoaderStatus.Processing);
+                splatBuffersAddedUIUpdate(firstBuild, finalBuild);
+            });
 
         };
 
@@ -916,7 +916,7 @@ export class Viewer {
     downloadAndBuildSingleSplatSceneStandardLoad(path, format, splatAlphaRemovalThreshold, buildFunc, onProgress, onException) {
 
         const downloadPromise = this.downloadSplatSceneToSplatBuffer(path, splatAlphaRemovalThreshold,
-            onProgress, false, undefined, format);
+                                                                     onProgress, false, undefined, format);
         const downloadAndBuildPromise = abortablePromiseWithExtractedComponents(downloadPromise.abortHandler);
 
         downloadPromise.then((splatBuffer) => {
@@ -926,13 +926,13 @@ export class Viewer {
                 this.clearSplatSceneDownloadAndBuildPromise();
             });
         })
-            .catch((e) => {
-                if (onException) onException();
-                this.clearSplatSceneDownloadAndBuildPromise();
-                this.removeSplatSceneDownloadPromise(downloadPromise);
-                const error = (e instanceof AbortedPromiseError) ? e : new Error(`Viewer::addSplatScene -> Could not load file ${path}`);
-                downloadAndBuildPromise.reject(error);
-            });
+        .catch((e) => {
+            if (onException) onException();
+            this.clearSplatSceneDownloadAndBuildPromise();
+            this.removeSplatSceneDownloadPromise(downloadPromise);
+            const error = (e instanceof AbortedPromiseError) ? e : new Error(`Viewer::addSplatScene -> Could not load file ${path}`);
+            downloadAndBuildPromise.reject(error);
+        });
 
         this.addSplatSceneDownloadPromise(downloadPromise);
         this.setSplatSceneDownloadAndBuildPromise(downloadAndBuildPromise.promise);
@@ -969,24 +969,19 @@ export class Viewer {
             .then((fileData) => {
                 // Read the data from the file
                 let buildScenePromise = this.loadSplatSceneFromFileToSplatBuffer(fileData, splatAlphaRemovalThreshold, onProgress, false, undefined, format);
-                // abortPromise = abortablePromiseWithExtractedComponents(loadFileDataPromise.abortHandler);
                 return buildScenePromise;
             })
             .then((splatBuffer) => {
-                console.log('splatBuffer')
                 // Construct a scene from the splatBuffer
                 this.removeSplatSceneDownloadPromise(loadFileDataPromise);
                 return buildFunc(splatBuffer, true, true).then(() => {
-                    // abortPromise.resolve();
                     this.clearSplatSceneDownloadAndBuildPromise();
                 });
             })
             .catch((e) => {
-                console.log(e)
                 if (onException) onException();
                 this.clearSplatSceneDownloadAndBuildPromise();
                 const error = (e instanceof AbortedPromiseError) ? e : new Error(`Viewer::addSplatScene -> Could not load file ${file.fileName}`);
-                // abortPromise.reject(error);
             });
 
         return loadAndBuildPromise;
@@ -1005,7 +1000,7 @@ export class Viewer {
      * @return {AbortablePromise}
      */
     downloadAndBuildSingleSplatSceneProgressiveLoad(path, format, splatAlphaRemovalThreshold, buildFunc,
-        onDownloadProgress, onDownloadException) {
+                                                    onDownloadProgress, onDownloadException) {
         let progressiveLoadedSectionBuildCount = 0;
         let progressiveLoadedSectionBuilding = false;
         const queuedProgressiveLoadSectionBuilds = [];
@@ -1017,19 +1012,19 @@ export class Viewer {
                 progressiveLoadedSectionBuilding = true;
                 const queuedBuild = queuedProgressiveLoadSectionBuilds.shift();
                 buildFunc(queuedBuild.splatBuffer, queuedBuild.firstBuild, queuedBuild.finalBuild)
-                    .then(() => {
-                        progressiveLoadedSectionBuilding = false;
-                        if (queuedBuild.firstBuild) {
-                            progressiveLoadFirstSectionBuildPromise.reject = null;
-                            progressiveLoadFirstSectionBuildPromise.resolve();
-                        } else if (queuedBuild.finalBuild) {
-                            splatSceneDownloadAndBuildPromise.resolve();
-                            this.clearSplatSceneDownloadAndBuildPromise();
-                        }
-                        if (queuedProgressiveLoadSectionBuilds.length > 0) {
-                            delayedExecute(() => checkAndBuildProgressiveLoadSections());
-                        }
-                    });
+                .then(() => {
+                    progressiveLoadedSectionBuilding = false;
+                    if (queuedBuild.firstBuild) {
+                        progressiveLoadFirstSectionBuildPromise.reject = null;
+                        progressiveLoadFirstSectionBuildPromise.resolve();
+                    } else if (queuedBuild.finalBuild) {
+                        splatSceneDownloadAndBuildPromise.resolve();
+                        this.clearSplatSceneDownloadAndBuildPromise();
+                    }
+                    if (queuedProgressiveLoadSectionBuilds.length > 0) {
+                        delayedExecute(() => checkAndBuildProgressiveLoadSections());
+                    }
+                });
             }
         };
 
@@ -1049,7 +1044,7 @@ export class Viewer {
         };
 
         let splatSceneDownloadPromise = this.downloadSplatSceneToSplatBuffer(path, splatAlphaRemovalThreshold, onDownloadProgress, true,
-            onProgressiveLoadSectionProgress, format);
+                                                                             onProgressiveLoadSectionProgress, format);
 
         const progressiveLoadFirstSectionBuildPromise = abortablePromiseWithExtractedComponents(splatSceneDownloadPromise.abortHandler);
         const splatSceneDownloadAndBuildPromise = abortablePromiseWithExtractedComponents();
@@ -1060,13 +1055,13 @@ export class Viewer {
         splatSceneDownloadPromise.then(() => {
             this.removeSplatSceneDownloadPromise(splatSceneDownloadPromise);
         })
-            .catch((e) => {
-                this.clearSplatSceneDownloadAndBuildPromise();
-                this.removeSplatSceneDownloadPromise(splatSceneDownloadPromise);
-                const error = (e instanceof AbortedPromiseError) ? e : new Error(`Viewer::addSplatScene -> Could not load one or more scenes`);
-                progressiveLoadFirstSectionBuildPromise.reject(error);
-                if (onDownloadException) onDownloadException(error);
-            });
+        .catch((e) => {
+            this.clearSplatSceneDownloadAndBuildPromise();
+            this.removeSplatSceneDownloadPromise(splatSceneDownloadPromise);
+            const error = (e instanceof AbortedPromiseError) ? e : new Error(`Viewer::addSplatScene -> Could not load one or more scenes`);
+            progressiveLoadFirstSectionBuildPromise.reject(error);
+            if (onDownloadException) onDownloadException(error);
+        });
 
         return progressiveLoadFirstSectionBuildPromise.promise;
     }
@@ -1118,7 +1113,7 @@ export class Viewer {
             if (showLoadingUI) {
                 if (loaderStatus === LoaderStatus.Downloading) {
                     this.loadingSpinner.setMessageForTask(loadingUITaskId, totalPercent == 100 ?
-                        `Download complete!` : `Downloading: ${percentLabel}`);
+                                                          `Download complete!` : `Downloading: ${percentLabel}`);
                 }
             }
             if (onProgress) onProgress(totalPercent, percentLabel, loaderStatus);
@@ -1130,32 +1125,32 @@ export class Viewer {
             const options = sceneOptions[i];
             const format = (options.format !== undefined && options.format !== null) ? options.format : sceneFormatFromPath(options.path);
             const baseDownloadPromise = this.downloadSplatSceneToSplatBuffer(options.path, options.splatAlphaRemovalThreshold,
-                onLoadProgress.bind(this, i), false, undefined, format);
+                                                                             onLoadProgress.bind(this, i), false, undefined, format);
             baseDownloadPromises.push(baseDownloadPromise);
             nativeDownloadPromises.push(baseDownloadPromise.promise);
         }
 
         const downloadAndBuildPromise = new AbortablePromise((resolve, reject) => {
             Promise.all(nativeDownloadPromises)
-                .then((splatBuffers) => {
-                    if (showLoadingUI) this.loadingSpinner.removeTask(loadingUITaskId);
-                    if (onProgress) onProgress(0, '0%', LoaderStatus.Processing);
-                    this.addSplatBuffers(splatBuffers, sceneOptions, true, showLoadingUI, showLoadingUI, false, false).then(() => {
-                        if (onProgress) onProgress(100, '100%', LoaderStatus.Processing);
-                        this.clearSplatSceneDownloadAndBuildPromise();
-                        resolve();
-                    });
-                })
-                .catch((e) => {
-                    if (showLoadingUI) this.loadingSpinner.removeTask(loadingUITaskId);
+            .then((splatBuffers) => {
+                if (showLoadingUI) this.loadingSpinner.removeTask(loadingUITaskId);
+                if (onProgress) onProgress(0, '0%', LoaderStatus.Processing);
+                this.addSplatBuffers(splatBuffers, sceneOptions, true, showLoadingUI, showLoadingUI, false, false).then(() => {
+                    if (onProgress) onProgress(100, '100%', LoaderStatus.Processing);
                     this.clearSplatSceneDownloadAndBuildPromise();
-                    const error = (e instanceof AbortedPromiseError) ? e :
-                        new Error(`Viewer::addSplatScenes -> Could not load one or more splat scenes.`);
-                    reject(error);
-                })
-                .finally(() => {
-                    this.removeSplatSceneDownloadPromise(downloadAndBuildPromise);
+                    resolve();
                 });
+            })
+            .catch((e) => {
+                if (showLoadingUI) this.loadingSpinner.removeTask(loadingUITaskId);
+                this.clearSplatSceneDownloadAndBuildPromise();
+                const error = (e instanceof AbortedPromiseError) ? e :
+                               new Error(`Viewer::addSplatScenes -> Could not load one or more splat scenes.`);
+                reject(error);
+            })
+            .finally(() => {
+                this.removeSplatSceneDownloadPromise(downloadAndBuildPromise);
+            });
         }, (reason) => {
             for (let baseDownloadPromise of baseDownloadPromises) {
                 baseDownloadPromise.abort(reason);
@@ -1179,15 +1174,15 @@ export class Viewer {
      * @return {AbortablePromise}
      */
     downloadSplatSceneToSplatBuffer(path, splatAlphaRemovalThreshold = 1, onProgress = undefined,
-        progressiveBuild = false, onSectionBuilt = undefined, format) {
+                                    progressiveBuild = false, onSectionBuilt = undefined, format) {
         if (format === SceneFormat.Splat) {
             return SplatLoader.loadFromURL(path, onProgress, progressiveBuild,
-                onSectionBuilt, splatAlphaRemovalThreshold, 0, false);
+                                           onSectionBuilt, splatAlphaRemovalThreshold, 0, false);
         } else if (format === SceneFormat.KSplat) {
             return KSplatLoader.loadFromURL(path, onProgress, progressiveBuild, onSectionBuilt);
         } else if (format === SceneFormat.Ply) {
             return PlyLoader.loadFromURL(path, onProgress, progressiveBuild, onSectionBuilt,
-                splatAlphaRemovalThreshold, this.plyInMemoryCompressionLevel, this.sphericalHarmonicsDegree);
+                                         splatAlphaRemovalThreshold, this.plyInMemoryCompressionLevel, this.sphericalHarmonicsDegree);
         }
 
         throw new Error(`Viewer::downloadSplatSceneToSplatBuffer -> File format not supported: ${path}`);
@@ -1229,8 +1224,8 @@ export class Viewer {
     addSplatBuffers = function() {
 
         return function(splatBuffers, splatBufferOptions = [], finalBuild = true, showLoadingUI = true,
-            showLoadingUIForSplatTreeBuild = true, replaceExisting = false,
-            enableRenderBeforeFirstSort = false, preserveVisibleRegion = true) {
+                        showLoadingUIForSplatTreeBuild = true, replaceExisting = false,
+                        enableRenderBeforeFirstSort = false, preserveVisibleRegion = true) {
 
             if (this.isDisposingOrDisposed()) return Promise.resolve();
 
@@ -1292,12 +1287,12 @@ export class Viewer {
                         resolve();
                     } else {
                         const buildResults = this.addSplatBuffersToMesh(splatBuffers, splatBufferOptions, finalBuild,
-                            showLoadingUIForSplatTreeBuild, replaceExisting,
-                            preserveVisibleRegion);
+                                                                        showLoadingUIForSplatTreeBuild, replaceExisting,
+                                                                        preserveVisibleRegion);
                         const maxSplatCount = this.splatMesh.getMaxSplatCount();
                         if (this.sortWorker && this.sortWorker.maxSplatCount !== maxSplatCount) this.disposeSortWorker();
                         const sortWorkerSetupPromise = (!this.sortWorker && maxSplatCount > 0) ?
-                            this.setupSortWorker(this.splatMesh) : Promise.resolve();
+                                                         this.setupSortWorker(this.splatMesh) : Promise.resolve();
                         sortWorkerSetupPromise.then(() => {
                             finish(buildResults, resolve);
                         });
@@ -1333,7 +1328,7 @@ export class Viewer {
         let splatOptimizingTaskId;
 
         return function(splatBuffers, splatBufferOptions, finalBuild = true, showLoadingUIForSplatTreeBuild = false,
-            replaceExisting = false, preserveVisibleRegion = true) {
+                        replaceExisting = false, preserveVisibleRegion = true) {
             if (this.isDisposingOrDisposed()) return;
             let allSplatBuffers = [];
             let allSplatBufferOptions = [];
@@ -1362,7 +1357,7 @@ export class Viewer {
                 }
             };
             const buildResults = this.splatMesh.build(allSplatBuffers, allSplatBufferOptions, true, finalBuild, onSplatTreeIndexesUpload,
-                onSplatTreeReady, preserveVisibleRegion);
+                                                      onSplatTreeReady, preserveVisibleRegion);
             if (finalBuild && this.freeIntermediateSplatData) this.splatMesh.freeIntermediateSplatData();
             return buildResults;
         };
@@ -1381,7 +1376,7 @@ export class Viewer {
             const splatCount = splatMesh.getSplatCount();
             const maxSplatCount = splatMesh.getMaxSplatCount();
             this.sortWorker = createSortWorker(maxSplatCount, this.sharedMemoryForWorkers, this.enableSIMDInSort,
-                this.integerBasedSort, this.splatMesh.dynamicMode);
+                                               this.integerBasedSort, this.splatMesh.dynamicMode);
             this.sortWorker.onmessage = (e) => {
                 if (e.data.sortDone) {
                     this.sortRunning = false;
@@ -1407,14 +1402,14 @@ export class Viewer {
                     if (this.logLevel >= LogLevel.Info) console.log('Sorting web worker WASM setup complete.');
                     if (this.sharedMemoryForWorkers) {
                         this.sortWorkerSortedIndexes = new Uint32Array(e.data.sortedIndexesBuffer,
-                            e.data.sortedIndexesOffset, maxSplatCount);
+                                                                       e.data.sortedIndexesOffset, maxSplatCount);
                         this.sortWorkerIndexesToSort = new Uint32Array(e.data.indexesToSortBuffer,
-                            e.data.indexesToSortOffset, maxSplatCount);
+                                                                       e.data.indexesToSortOffset, maxSplatCount);
                         this.sortWorkerPrecomputedDistances = new DistancesArrayType(e.data.precomputedDistancesBuffer,
-                            e.data.precomputedDistancesOffset,
-                            maxSplatCount);
+                                                                                     e.data.precomputedDistancesOffset,
+                                                                                     maxSplatCount);
                         this.sortWorkerTransforms = new Float32Array(e.data.transformsBuffer,
-                            e.data.transformsOffset, Constants.MaxScenes * 16);
+                                                                     e.data.transformsOffset, Constants.MaxScenes * 16);
                     } else {
                         this.sortWorkerIndexesToSort = new Uint32Array(maxSplatCount);
                         this.sortWorkerPrecomputedDistances = new DistancesArrayType(maxSplatCount);
@@ -1525,33 +1520,33 @@ export class Viewer {
                 this.sceneRevealMode = SceneRevealMode.Instant;
                 this.createSplatMesh();
                 this.addSplatBuffers(savedSplatBuffers, savedSceneOptions, true, false, true)
-                    .then(() => {
-                        if (checkForEarlyExit()) return;
-                        checkAndHideLoadingUI();
-                        this.splatMesh.scenes.forEach((scene, index) => {
-                            scene.position.copy(savedSceneTransformComponents[index].position);
-                            scene.quaternion.copy(savedSceneTransformComponents[index].quaternion);
-                            scene.scale.copy(savedSceneTransformComponents[index].scale);
-                        });
-                        this.splatMesh.updateTransforms();
-                        this.splatRenderReady = false;
-
-                        this.runSplatSort(true)
-                            .then(() => {
-                                if (checkForEarlyExit()) {
-                                    this.splatRenderReady = true;
-                                    return;
-                                }
-                                sortPromise = this.sortPromise || Promise.resolve();
-                                sortPromise.then(() => {
-                                    this.splatRenderReady = true;
-                                    onDone();
-                                });
-                            });
-                    })
-                    .catch((e) => {
-                        onDone(e);
+                .then(() => {
+                    if (checkForEarlyExit()) return;
+                    checkAndHideLoadingUI();
+                    this.splatMesh.scenes.forEach((scene, index) => {
+                        scene.position.copy(savedSceneTransformComponents[index].position);
+                        scene.quaternion.copy(savedSceneTransformComponents[index].quaternion);
+                        scene.scale.copy(savedSceneTransformComponents[index].scale);
                     });
+                    this.splatMesh.updateTransforms();
+                    this.splatRenderReady = false;
+
+                    this.runSplatSort(true)
+                    .then(() => {
+                        if (checkForEarlyExit()) {
+                            this.splatRenderReady = true;
+                            return;
+                        }
+                        sortPromise = this.sortPromise || Promise.resolve();
+                        sortPromise.then(() => {
+                            this.splatRenderReady = true;
+                            onDone();
+                        });
+                    });
+                })
+                .catch((e) => {
+                    onDone(e);
+                });
             });
         });
 
@@ -1695,16 +1690,16 @@ export class Viewer {
                 const cp = this.camera.position;
                 const co = this.camera.quaternion;
                 cameraChanged = Math.abs(cp.x - lastCameraPosition.x) > changeEpsilon ||
-                    Math.abs(cp.y - lastCameraPosition.y) > changeEpsilon ||
-                    Math.abs(cp.z - lastCameraPosition.z) > changeEpsilon ||
-                    Math.abs(co.x - lastCameraOrientation.x) > changeEpsilon ||
-                    Math.abs(co.y - lastCameraOrientation.y) > changeEpsilon ||
-                    Math.abs(co.z - lastCameraOrientation.z) > changeEpsilon ||
-                    Math.abs(co.w - lastCameraOrientation.w) > changeEpsilon;
+                                Math.abs(cp.y - lastCameraPosition.y) > changeEpsilon ||
+                                Math.abs(cp.z - lastCameraPosition.z) > changeEpsilon ||
+                                Math.abs(co.x - lastCameraOrientation.x) > changeEpsilon ||
+                                Math.abs(co.y - lastCameraOrientation.y) > changeEpsilon ||
+                                Math.abs(co.z - lastCameraOrientation.z) > changeEpsilon ||
+                                Math.abs(co.w - lastCameraOrientation.w) > changeEpsilon;
             }
 
             shouldRender = this.renderMode !== RenderMode.Never && (renderCount === 0 || this.splatMesh.visibleRegionChanging ||
-                cameraChanged || this.renderMode === RenderMode.Always || this.dynamicMode === true || this.renderNextFrame);
+                           cameraChanged || this.renderMode === RenderMode.Always || this.dynamicMode === true || this.renderNextFrame);
 
             if (this.camera) {
                 lastCameraPosition.copy(this.camera.position);
@@ -1932,10 +1927,10 @@ export class Viewer {
             const meshCursorPosition = this.showMeshCursor ? this.sceneHelper.meshCursor.position : null;
             const splatRenderCountPct = splatCount > 0 ? this.splatRenderCount / splatCount * 100 : 0;
             this.infoPanel.update(renderDimensions, this.camera.position, cameraLookAtPosition,
-                this.camera.up, this.camera.isOrthographicCamera, meshCursorPosition,
-                this.currentFPS || 'N/A', splatCount, this.splatRenderCount, splatRenderCountPct,
-                this.lastSortTime, this.focalAdjustment, this.splatMesh.getSplatScale(),
-                this.splatMesh.getPointCloudModeEnabled());
+                                  this.camera.up, this.camera.isOrthographicCamera, meshCursorPosition,
+                                  this.currentFPS || 'N/A', splatCount, this.splatRenderCount, splatRenderCountPct,
+                                  this.lastSortTime, this.focalAdjustment, this.splatMesh.getSplatScale(),
+                                  this.splatMesh.getPointCloudModeEnabled());
         };
 
     }();
@@ -2158,7 +2153,7 @@ export class Viewer {
                     const windowSizeInts = node.data.indexes.length;
                     const windowSizeBytes = windowSizeInts * Constants.BytesPerInt;
                     let destView = new Uint32Array(this.sortWorkerIndexesToSort.buffer,
-                        currentByteOffset - windowSizeBytes, windowSizeInts);
+                                                   currentByteOffset - windowSizeBytes, windowSizeInts);
                     destView.set(node.data.indexes);
                     currentByteOffset -= windowSizeBytes;
                 }


### PR DESCRIPTION
For now, the viewer can handle URL which can be downloaded from with the `fetch` API.
I wanted to add the possibility to load a scene directly from a file, to handle drag & drop for instance.

Some features are still missing, like the progressive loading, or multiple files loading. I plan on integrate these soon.

Moreover, I struggled a bit on the 'abortable' promise that is returned by `downloadAndBuildSingleSplatSceneStandardLoad`. I couldn't manage to get the differences between the two following lines  : 
```js        
const downloadPromise = this.downloadSplatSceneToSplatBuffer(path, splatAlphaRemovalThreshold, onProgress, false, undefined, format);
const downloadAndBuildPromise = abortablePromiseWithExtractedComponents(downloadPromise.abortHandler);
```