### PR TITLE
Add request headers option for loaders

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -285,6 +285,7 @@
     let currentCameraPositionArray;
     let currentCameraLookAtArray;
     let currentAntialiased;
+    let current2DScene;
     let currentSphericalHarmonicsDegree;
   </script>
   <script type="module">
@@ -455,6 +456,7 @@
       let cameraPositionArray = document.getElementById("cameraPosition").value;
       let cameraLookAtArray = document.getElementById("cameraLookAt").value;
       let antialiased = document.getElementById("antialiased").checked;
+      let sceneIs2D = document.getElementById("2dScene").checked;
       let sphericalHarmonicsDegree = parseInt(document.getElementById("viewSphericalHarmonicsDegree").value);
 
       cameraUpArray = cameraUpArray.split(',');
@@ -516,13 +518,14 @@
       currentCameraPositionArray = cameraPositionArray;
       currentCameraLookAtArray = cameraLookAtArray;
       currentAntialiased = antialiased;
+      current2DScene = sceneIs2D;
       currentSphericalHarmonicsDegree = sphericalHarmonicsDegree;
 
       try {
         const fileReader = new FileReader();
         fileReader.onload = function(){
           try {
-           runViewer(fileReader.result, format, alphaRemovalThreshold, cameraUpArray, cameraPositionArray, cameraLookAtArray, antialiased, sphericalHarmonicsDegree);
+           runViewer(fileReader.result, format, alphaRemovalThreshold, cameraUpArray, cameraPositionArray, cameraLookAtArray, antialiased, sceneIs2D, sphericalHarmonicsDegree);
           } catch (e) {
             console.error(e);
             setViewError("Could not view scene.");
@@ -554,19 +557,20 @@
   
     window.addEventListener("popstate", (event) => {
       if (currentAlphaRemovalThreshold !== undefined) {
-        window.location = 'index.html?art=' + currentAlphaRemovalThreshold + '&cu=' + currentCameraUpArray + "&cp=" + currentCameraPositionArray + "&cla=" + currentCameraLookAtArray + "&aa=" + currentAntialiased + "&sh=" + currentSphericalHarmonicsDegree;
+        window.location = 'index.html?art=' + currentAlphaRemovalThreshold + '&cu=' + currentCameraUpArray + "&cp=" + currentCameraPositionArray + "&cla=" + currentCameraLookAtArray + "&aa=" + currentAntialiased + "&2d=" + current2DScene + "&sh=" + currentSphericalHarmonicsDegree;
       } else {
         window.location = 'index.html';
       }
     });
 
-    function runViewer(splatBufferData, format, alphaRemovalThreshold, cameraUpArray, cameraPositionArray, cameraLookAtArray, antialiased, sphericalHarmonicsDegree) {
+    function runViewer(splatBufferData, format, alphaRemovalThreshold, cameraUpArray, cameraPositionArray, cameraLookAtArray, antialiased, sceneIs2D, sphericalHarmonicsDegree) {
       const viewerOptions = {
         'cameraUp': cameraUpArray,
         'initialCameraPosition': cameraPositionArray,
         'initialCameraLookAt': cameraLookAtArray,
         'halfPrecisionCovariancesOnGPU': false,
         'antialiased': antialiased || false,
+        'splatRenderMode': sceneIs2D ? GaussianSplats3D.SplatRenderMode.TwoD : GaussianSplats3D.SplatRenderMode.ThreeD,
         'sphericalHarmonicsDegree': sphericalHarmonicsDegree
       };
       const splatBufferOptions = {
@@ -687,7 +691,7 @@
     <br>
     <div class="header-content-container">
         <div class="content-row">
-            <div id ="view-panel" class="splat-panel" style="height:370px;">
+            <div id ="view-panel" class="splat-panel" style="height:400px;">
                 <br>
                 <div class="small-title">View a <span class="file-ext">.ply</span>, <span class="file-ext">.ksplat</span>, or <span class="file-ext-small">.splat</span> file</div>
                 <br>
@@ -716,8 +720,16 @@
                       <td>
                         Anti-aliased
                       </td>
-                      <td style="text-align:lefts;">
+                      <td style="text-align:left;">
                         <input type="checkbox" id="antialiased" class="checkbox-input"/>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        2D scene
+                      </td>
+                      <td style="text-align:left;">
+                        <input type="checkbox" id="2dScene" class="checkbox-input"/>
                       </td>
                     </tr>
                     <tr>
@@ -981,6 +993,9 @@
         } else if (varName == "aa") {
           currentAntialiased = component[1] === 'true' ? true : false;
           document.getElementById('antialiased').checked = currentAntialiased;
+        } else if (varName == "2d") {
+          current2DScene = component[1] === 'true' ? true : false;
+          document.getElementById('2dScene').checked = current2DScene;
         }  else if (varName == "sh") {
           currentSphericalHarmonicsDegree = component[1];
           document.getElementById('viewSphericalHarmonicsDegree').value = currentSphericalHarmonicsDegree;

--- a/src/Util.js
+++ b/src/Util.js
@@ -54,10 +54,11 @@ export const rgbaArrayToInteger = function(arr, offset) {
     return arr[offset] + (arr[offset + 1] << 8) + (arr[offset + 2] << 16) + (arr[offset + 3] << 24);
 };
 
-export const fetchWithProgress = function(path, onProgress, saveChunks = true) {
+export const fetchWithProgress = function(path, headers, onProgress, saveChunks = true) {
 
     const abortController = new AbortController();
     const signal = abortController.signal;
+    const requestHeaders = headers ? headers : new Headers();
     let aborted = false;
     const abortHandler = (reason) => {
         abortController.abort(reason);
@@ -65,7 +66,7 @@ export const fetchWithProgress = function(path, onProgress, saveChunks = true) {
     };
 
     return new AbortablePromise((resolve, reject) => {
-        fetch(path, { signal })
+        fetch(path, { headers: requestHeaders, signal })
         .then(async (data) => {
             // Handle error conditions where data is still returned
             if (!data.ok) {

--- a/src/loaders/ksplat/KSplatLoader.js
+++ b/src/loaders/ksplat/KSplatLoader.js
@@ -19,7 +19,7 @@ export class KSplatLoader {
         }
     };
 
-    static loadFromURL(fileName, externalOnProgress, loadDirectoToSplatBuffer, onSectionBuilt) {
+    static loadFromURL(fileName, headers, externalOnProgress, loadDirectoToSplatBuffer, onSectionBuilt) {
         let directLoadBuffer;
         let directLoadSplatBuffer;
 
@@ -196,7 +196,7 @@ export class KSplatLoader {
             }
         };
 
-        return fetchWithProgress(fileName, localOnProgress, !loadDirectoToSplatBuffer).then((fullBuffer) => {
+        return fetchWithProgress(fileName, headers, localOnProgress, !loadDirectoToSplatBuffer).then((fullBuffer) => {
             if (externalOnProgress) externalOnProgress(0, '0%', LoaderStatus.Processing);
             const loadPromise = loadDirectoToSplatBuffer ? directLoadPromise.promise : KSplatLoader.loadFromFileData(fullBuffer);
             return loadPromise.then((splatBuffer) => {

--- a/src/loaders/ply/PlyLoader.js
+++ b/src/loaders/ply/PlyLoader.js
@@ -43,7 +43,7 @@ function finalize(splatData, optimizeSplatData, minimumAlpha, compressionLevel, 
 
 export class PlyLoader {
 
-    static loadFromURL(fileName, onProgress, loadDirectoToSplatBuffer, onProgressiveLoadSectionProgress, minimumAlpha, compressionLevel,
+    static loadFromURL(fileName, headers, onProgress, loadDirectoToSplatBuffer, onProgressiveLoadSectionProgress, minimumAlpha, compressionLevel,
                        optimizeSplatData = true, outSphericalHarmonicsDegree = 0, sectionSize, sceneCenter, blockSize, bucketSize) {
 
         let internalLoadType = loadDirectoToSplatBuffer ? InternalLoadType.DirectToSplatBuffer : InternalLoadType.DirectToSplatArray;
@@ -256,7 +256,7 @@ export class PlyLoader {
         };
 
         if (onProgress) onProgress(0, '0%', LoaderStatus.Downloading);
-        return fetchWithProgress(fileName, localOnProgress, false).then(() => {
+        return fetchWithProgress(fileName, headers, localOnProgress, false).then(() => {
             if (onProgress) onProgress(0, '0%', LoaderStatus.Processing);
             return loadPromise.promise.then((splatData) => {
                 if (onProgress) onProgress(100, '100%', LoaderStatus.Done);

--- a/src/loaders/splat/SplatLoader.js
+++ b/src/loaders/splat/SplatLoader.js
@@ -22,7 +22,7 @@ function finalize(splatData, optimizeSplatData, minimumAlpha, compressionLevel, 
 
 export class SplatLoader {
 
-    static loadFromURL(fileName, onProgress, loadDirectoToSplatBuffer, onProgressiveLoadSectionProgress, minimumAlpha, compressionLevel,
+    static loadFromURL(fileName, headers, onProgress, loadDirectoToSplatBuffer, onProgressiveLoadSectionProgress, minimumAlpha, compressionLevel,
                        optimizeSplatData = true, sectionSize, sceneCenter, blockSize, bucketSize) {
 
         let internalLoadType = loadDirectoToSplatBuffer ? InternalLoadType.DirectToSplatBuffer : InternalLoadType.DirectToSplatArray;
@@ -149,7 +149,7 @@ export class SplatLoader {
         };
 
         if (onProgress) onProgress(0, '0%', LoaderStatus.Downloading);
-        return fetchWithProgress(fileName, localOnProgress, false).then(() => {
+        return fetchWithProgress(fileName, headers, localOnProgress, false).then(() => {
             if (onProgress) onProgress(0, '0%', LoaderStatus.Processing);
             return loadPromise.promise.then((splatData) => {
                 if (onProgress) onProgress(100, '100%', LoaderStatus.Done);


### PR DESCRIPTION
Adding an optional headers parameter which can be used to provide headers (such as Bearer Tokens). This allows for secured or authorized endpoints to be used when streaming data.