### PR TITLE
Remove callbackMesh geometry and material in DropInViewer.dispose

### DIFF
--- a/src/DropInViewer.js
+++ b/src/DropInViewer.js
@@ -116,6 +116,8 @@ export class DropInViewer extends THREE.Group {
     }
 
     async dispose() {
+        this.callbackMesh.geometry.dispose();
+        this.callbackMesh.material.dispose();
         return await this.viewer.dispose();
     }
 


### PR DESCRIPTION
Remove callbackMesh geometry and material in DropInViewer.dispose, that callbackMesh is created in init but never disposed.

I tested it as follow, edit `demo/dropin.html` to add the two lines to dispose after 10s
```js
viewer.callbackMesh.material.addEventListener('dispose', () => { console.log("disposed"); });
setTimeout(() => { threeScene.remove(viewer); viewer.dispose(); }, 10000);
```

```
npm run build
npm run demo
```

Go to http://localhost:8080/dropin.html
the console.log doesn't show up.

I did the change in `src/DropInViewer.js`
```
npm run build
npm run demo
```
Refresh http://localhost:8080/dropin.html
the console.log `disposed` shows up.
