### PR TITLE
Fail to determine file type if url has extra params

### DIFF
--- a/src/loaders/Utils.js
+++ b/src/loaders/Utils.js
@@ -1,6 +1,12 @@
 import { SceneFormat } from './SceneFormat.js';
 
 export const sceneFormatFromPath = (path) => {
+    try {
+      const url = new URL(path);
+      path = url.pathname;
+    } catch (e) {
+      // Ignore error, path is not a URL
+    }
     if (path.endsWith('.ply')) return SceneFormat.Ply;
     else if (path.endsWith('.splat')) return SceneFormat.Splat;
     else if (path.endsWith('.ksplat')) return SceneFormat.KSplat;


### PR DESCRIPTION
Currently, if you provide a URL with a extra parameters, `sceneFormatFromPath` would fail to gather what extension it could be.

for example, you could have a signed url such as:
```sh
https://storage.googleapis.com/a_bucket/blob.splat?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Signature=1ba94...d14221
```

and it would produce `null` as a result, because the `path` was not curated correctly for URLs, correcting the `pathname` from the url would have a better chance of gathering the possible extension type.